### PR TITLE
Updates to scripts and testing to run automated tests

### DIFF
--- a/dpdk/Dockerfile
+++ b/dpdk/Dockerfile
@@ -1,8 +1,9 @@
-# Copyright 2017 Intel Corporation. 
+# Copyright 2017 Intel Corporation.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-FROM nff-go-base
+ARG USER_NAME
+FROM ${USER_NAME}/nff-go-base
 
 LABEL RUN docker run -it --privileged -v /sys/bus/pci/drivers:/sys/bus/pci/drivers -v /sys/kernel/mm/hugepages:/sys/kernel/mm/hugepages -v /sys/devices/system/node:/sys/devices/system/node -v /dev:/dev --name NAME -e NAME=NAME -e IMAGE=IMAGE IMAGE
 

--- a/dpdk/Makefile
+++ b/dpdk/Makefile
@@ -7,8 +7,6 @@ IMAGENAME = nff-go-pktgen
 
 # Pktgen variables
 NOCHECK_PKTGEN = yes
-PKTGEN_VERSION=3.4.0
-PKTGEN_DIR=pktgen-$(PKTGEN_VERSION)
 
 include $(PATH_TO_MK)/leaf.mk
 
@@ -25,14 +23,14 @@ all: pktgen
 	cp $(PKTGEN_DIR)/Pktgen.lua .
 
 $(DPDK_DIR):
-	curl -L -s http://fast.dpdk.org/rel/dpdk-$(DPDK_VERSION).tar.xz | tar xJ
+	curl -L -s $(DPDK_URL) | tar xJ
 
 $(DPDK_DIR)/$(DPDK_INSTALL_DIR): $(DPDK_DIR)
 	$(MAKE) -C $(DPDK_DIR) config T=$(RTE_TARGET)
 	$(MAKE) -C $(DPDK_DIR) install T=$(RTE_TARGET) DESTDIR=$(DPDK_INSTALL_DIR)
 
 $(PKTGEN_DIR):
-	curl -L -s http://dpdk.org/browse/apps/pktgen-dpdk/snapshot/pktgen-$(PKTGEN_VERSION).tar.xz | tar xJ
+	curl -L -s $(PKTGEN_URL) | tar xJ
 
 $(PKTGEN_DIR)/app/$(RTE_TARGET)/pktgen: $(DPDK_DIR)/$(DPDK_INSTALL_DIR) $(PKTGEN_DIR)
 	$(MAKE) -j1 -C $(PKTGEN_DIR)

--- a/examples/Dockerfile
+++ b/examples/Dockerfile
@@ -1,4 +1,9 @@
-FROM nff-go-base
+# Copyright 2017 Intel Corporation.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+ARG USER_NAME
+FROM ${USER_NAME}/nff-go-base
 
 LABEL RUN docker run -it --privileged -v /sys/bus/pci/drivers:/sys/bus/pci/drivers -v /sys/kernel/mm/hugepages:/sys/kernel/mm/hugepages -v /sys/devices/system/node:/sys/devices/system/node -v /dev:/dev --name NAME -e NAME=NAME -e IMAGE=IMAGE IMAGE
 

--- a/examples/antiddos/Dockerfile
+++ b/examples/antiddos/Dockerfile
@@ -1,8 +1,9 @@
-# Copyright 2017 Intel Corporation. 
+# Copyright 2017 Intel Corporation.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-FROM nff-go-base
+ARG USER_NAME
+FROM ${USER_NAME}/nff-go-base
 
 LABEL RUN docker run -it --privileged -v /sys/bus/pci/drivers:/sys/bus/pci/drivers -v /sys/kernel/mm/hugepages:/sys/kernel/mm/hugepages -v /sys/devices/system/node:/sys/devices/system/node -v /dev:/dev --name NAME -e NAME=NAME -e IMAGE=IMAGE IMAGE
 

--- a/examples/nat/main/Dockerfile
+++ b/examples/nat/main/Dockerfile
@@ -1,13 +1,13 @@
-# Copyright 2017 Intel Corporation. 
+# Copyright 2017 Intel Corporation.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-FROM nff-go-base
+ARG USER_NAME
+FROM ${USER_NAME}/nff-go-base
 
 LABEL RUN docker run -it --privileged -v /sys/bus/pci/drivers:/sys/bus/pci/drivers -v /sys/kernel/mm/hugepages:/sys/kernel/mm/hugepages -v /sys/devices/system/node:/sys/devices/system/node -v /dev:/dev --name NAME -e NAME=NAME -e IMAGE=IMAGE IMAGE
 
 WORKDIR /workdir
-
 COPY nat .
 COPY config.json .
 COPY config2ports.json .

--- a/examples/tutorial/Dockerfile
+++ b/examples/tutorial/Dockerfile
@@ -1,8 +1,9 @@
-# Copyright 2017 Intel Corporation. 
+# Copyright 2017 Intel Corporation.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-FROM nff-go-base
+ARG USER_NAME
+FROM ${USER_NAME}/nff-go-base
 
 LABEL RUN docker run -it --privileged -v /sys/bus/pci/drivers:/sys/bus/pci/drivers -v /sys/kernel/mm/hugepages:/sys/kernel/mm/hugepages -v /sys/devices/system/node:/sys/devices/system/node -v /dev:/dev --name NAME -e NAME=NAME -e IMAGE=IMAGE IMAGE
 

--- a/mk/include.mk
+++ b/mk/include.mk
@@ -8,6 +8,14 @@ PROJECT_ROOT := $(abspath $(dir $(abspath $(lastword $(MAKEFILE_LIST))))/..)
 
 DPDK_VERSION = 17.08
 DPDK_DIR = dpdk-$(DPDK_VERSION)
+ifndef DPDK_URL
+DPDK_URL=http://fast.dpdk.org/rel/dpdk-$(DPDK_VERSION).tar.xz
+endif
+PKTGEN_VERSION=3.4.0
+PKTGEN_DIR=pktgen-$(PKTGEN_VERSION)
+ifndef PKTGEN_URL
+PKTGEN_URL=http://dpdk.org/browse/apps/pktgen-dpdk/snapshot/pktgen-$(PKTGEN_VERSION).tar.xz
+endif
 export RTE_SDK = $(PROJECT_ROOT)/dpdk/$(DPDK_DIR)
 export RTE_TARGET = x86_64-native-linuxapp-gcc
 

--- a/nff-go-base/Makefile
+++ b/nff-go-base/Makefile
@@ -7,8 +7,9 @@ IMAGENAME = nff-go-base
 EXECUTABLES =
 NOCHECK_PKTGEN = yes
 
-Dockerfile:
-	echo 'FROM fedora' > Dockerfile
+Dockerfile: Makefile
+	echo 'ARG USER_NAME' > Dockerfile
+	echo 'FROM fedora' >> Dockerfile
 	if [ -n '${http_proxy}' ]; then					\
 		echo 'ENV http_proxy ${http_proxy}' >> Dockerfile;	\
 		echo 'ENV https_proxy ${http_proxy}' >> Dockerfile;	\

--- a/test/framework/config.go
+++ b/test/framework/config.go
@@ -46,10 +46,6 @@ type BenchmarkConfig struct {
 // AppConfig struct has settings controlling test
 // distributed application parameters.
 type AppConfig struct {
-	// Specifies host name where docker daemon is running. Port number
-	// is specified in DockerConfig structure and is the same for all
-	// hosts.
-	HostName string `json:"host-name"`
 	// Specifies docker image to run for this test application.
 	ImageName string `json:"image-name"`
 	// Specifies application type. Valid values are "TestAppGo" and "TestAppPktgen"
@@ -63,7 +59,7 @@ type AppConfig struct {
 }
 
 func (app *AppConfig) String() string {
-	return fmt.Sprintf("%s:%s", app.HostName, app.ImageName)
+	return fmt.Sprintf("%s:%d:%s", app.hp.host, app.hp.port, app.ImageName)
 }
 
 // TestConfig struct has settings for one test case.
@@ -107,9 +103,6 @@ type DockerConfig struct {
 	// container. If wrong filesystems are specified in this array,
 	// DPDK doesn't work.
 	Volumes []string `json:"map-volumes"`
-	// Network socket port to be used to communicate with docker
-	// daemon. Usually 2375.
-	DockerPort int `json:"docker-port"`
 	// Network socket port to be used to communicate with pktgen
 	// program. Usually 22022.
 	PktgenPort int `json:"pktgen-port"`
@@ -145,8 +138,9 @@ func ReadConfig(fileName string, hl HostsList) (*TestsuiteConfig, error) {
 			if jjj < len(hl) {
 				config.Tests[iii].Apps[jjj].hp = hl[jjj]
 			} else {
-				config.Tests[iii].Apps[jjj].hp.host = config.Tests[iii].Apps[jjj].HostName
-				config.Tests[iii].Apps[jjj].hp.port = config.Config.DockerPort
+				LogPanic("Host number ", jjj, " not defined on command line for test \"",
+					config.Tests[iii].Name,
+					"\"\nIt is necessary to specify hosts for all test applications in -hosts switch.\n")
 			}
 		}
 	}

--- a/test/framework/dockerlauncher.go
+++ b/test/framework/dockerlauncher.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"os"
 	"os/user"
 	"regexp"
 	"strconv"
@@ -44,6 +45,10 @@ var (
 func init() {
 	u, _ := user.Current()
 	username = u.Username
+	prefix, exists := os.LookupEnv("NFF_GO_IMAGE_PREFIX")
+	if exists {
+		username = prefix + "/" + username
+	}
 }
 
 // Measurement has measured by benchmark values.

--- a/test/framework/main/forwardperf.json
+++ b/test/framework/main/forwardperf.json
@@ -9,7 +9,6 @@
             "/sys/devices/system/node:/sys/devices/system/node",
             "/dev:/dev"
         ],
-        "docker-port": 2375,
         "pktgen-port": 22022
     },
     "tests": [
@@ -19,7 +18,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -27,7 +25,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -49,7 +46,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -57,7 +53,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [

--- a/test/framework/main/latency.json
+++ b/test/framework/main/latency.json
@@ -9,7 +9,6 @@
             "/sys/devices/system/node:/sys/devices/system/node",
             "/dev:/dev"
         ],
-        "docker-port": 2375,
         "pktgen-port": 22022
     },
     "tests": [
@@ -19,7 +18,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -27,7 +25,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -42,7 +39,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -50,7 +46,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -65,7 +60,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -73,7 +67,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [

--- a/test/framework/main/perf.json
+++ b/test/framework/main/perf.json
@@ -9,7 +9,6 @@
             "/sys/devices/system/node:/sys/devices/system/node",
             "/dev:/dev"
         ],
-        "docker-port": 2375,
         "pktgen-port": 22022
     },
     "tests": [
@@ -19,7 +18,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -27,7 +25,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -56,7 +53,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -64,7 +60,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -93,7 +88,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -101,7 +95,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -130,7 +123,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -138,7 +130,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -167,7 +158,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -175,7 +165,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -204,7 +193,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -212,7 +200,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -241,7 +228,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -249,7 +235,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -278,7 +263,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -286,7 +270,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -315,7 +298,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -323,7 +305,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -352,7 +333,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -360,7 +340,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -389,7 +368,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -397,7 +375,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -426,7 +403,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -434,7 +410,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -463,7 +438,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -471,7 +445,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -500,7 +473,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -508,7 +480,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -537,7 +508,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -545,7 +515,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -574,7 +543,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -582,7 +550,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -611,7 +578,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -619,7 +585,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -648,7 +613,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -656,7 +620,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -685,7 +648,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -693,7 +655,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -722,7 +683,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -730,7 +690,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -759,7 +718,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -767,7 +725,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -796,7 +753,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -804,7 +760,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -833,7 +788,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -841,7 +795,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -870,7 +823,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -878,7 +830,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -907,7 +858,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -915,7 +865,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -944,7 +893,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -952,7 +900,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -981,7 +928,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -989,7 +935,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -1018,7 +963,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -1026,7 +970,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -1055,7 +998,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -1063,7 +1005,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -1092,7 +1033,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -1100,7 +1040,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -1129,7 +1068,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -1137,7 +1075,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -1166,7 +1103,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -1174,7 +1110,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -1203,7 +1138,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -1211,7 +1145,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -1240,7 +1173,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -1248,7 +1180,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -1277,7 +1208,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -1285,7 +1215,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -1314,7 +1243,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -1322,7 +1250,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -1351,7 +1278,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -1359,7 +1285,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -1388,7 +1313,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -1396,7 +1320,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -1425,7 +1348,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -1433,7 +1355,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -1462,7 +1383,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -1470,7 +1390,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -1499,7 +1418,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -1507,7 +1425,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -1536,7 +1453,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -1544,7 +1460,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -1573,7 +1488,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -1581,7 +1495,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -1610,7 +1523,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -1618,7 +1530,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -1647,7 +1558,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -1655,7 +1565,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -1684,7 +1593,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -1692,7 +1600,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -1721,7 +1628,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -1729,7 +1635,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -1758,7 +1663,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -1766,7 +1670,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -1795,7 +1698,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -1803,7 +1705,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -1832,7 +1733,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -1840,7 +1740,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -1869,7 +1768,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -1877,7 +1775,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -1906,7 +1803,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -1914,7 +1810,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -1943,7 +1838,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -1951,7 +1845,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -1980,7 +1873,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -1988,7 +1880,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -2017,7 +1908,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -2025,7 +1915,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -2054,7 +1943,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -2062,7 +1950,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -2091,7 +1978,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -2099,7 +1985,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -2128,7 +2013,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -2136,7 +2020,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -2165,7 +2048,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -2173,7 +2055,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -2202,7 +2083,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -2210,7 +2090,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -2239,7 +2118,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -2247,7 +2125,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -2276,7 +2153,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -2284,7 +2160,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -2313,7 +2188,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -2321,7 +2195,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -2350,7 +2223,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -2358,7 +2230,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -2387,7 +2258,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -2395,7 +2265,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -2424,7 +2293,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -2432,7 +2300,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -2461,7 +2328,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -2469,7 +2335,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -2498,7 +2363,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -2506,7 +2370,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -2535,7 +2398,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -2543,7 +2405,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -2572,7 +2433,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -2580,7 +2440,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -2609,7 +2468,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -2617,7 +2475,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -2646,7 +2503,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -2654,7 +2510,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -2683,7 +2538,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -2691,7 +2545,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -2720,7 +2573,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -2728,7 +2580,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -2757,7 +2608,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -2765,7 +2615,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -2794,7 +2643,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -2802,7 +2650,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -2831,7 +2678,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -2839,7 +2685,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -2868,7 +2713,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -2876,7 +2720,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -2905,7 +2748,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -2913,7 +2755,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -2942,7 +2783,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -2950,7 +2790,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -2979,7 +2818,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -2987,7 +2825,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -3016,7 +2853,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -3024,7 +2860,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -3053,7 +2888,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -3061,7 +2895,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -3090,7 +2923,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -3098,7 +2930,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -3127,7 +2958,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -3135,7 +2965,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -3164,7 +2993,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -3172,7 +3000,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -3201,7 +3028,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -3209,7 +3035,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -3238,7 +3063,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -3246,7 +3070,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -3275,7 +3098,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -3283,7 +3105,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -3312,7 +3133,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -3320,7 +3140,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -3349,7 +3168,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -3357,7 +3175,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -3386,7 +3203,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -3394,7 +3210,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -3423,7 +3238,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -3431,7 +3245,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -3460,7 +3273,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -3468,7 +3280,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -3497,7 +3308,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -3505,7 +3315,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -3534,7 +3343,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -3542,7 +3350,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -3571,7 +3378,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -3579,7 +3385,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -3608,7 +3413,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -3616,7 +3420,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -3645,7 +3448,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -3653,7 +3455,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -3682,7 +3483,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -3690,7 +3490,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -3719,7 +3518,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -3727,7 +3525,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -3756,7 +3553,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -3764,7 +3560,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -3793,7 +3588,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -3801,7 +3595,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -3830,7 +3623,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -3838,7 +3630,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -3867,7 +3658,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -3875,7 +3665,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -3904,7 +3693,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -3912,7 +3700,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -3941,7 +3728,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -3949,7 +3735,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -3978,7 +3763,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -3986,7 +3770,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -4015,7 +3798,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -4023,7 +3805,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -4052,7 +3833,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -4060,7 +3840,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -4089,7 +3868,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -4097,7 +3875,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -4126,7 +3903,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -4134,7 +3910,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -4163,7 +3938,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -4171,7 +3945,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -4200,7 +3973,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -4208,7 +3980,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -4237,7 +4008,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-nat",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -4245,7 +4015,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -4294,7 +4063,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-nat",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -4302,7 +4070,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -4351,7 +4118,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-nat",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -4359,7 +4125,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -4408,7 +4173,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-nat",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -4416,7 +4180,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -4465,7 +4228,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-nat",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -4473,7 +4235,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -4522,7 +4283,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-nat",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -4530,7 +4290,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -4579,7 +4338,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-nat",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -4587,7 +4345,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -4636,7 +4393,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-nat",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -4644,7 +4400,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -4693,7 +4448,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-nat",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -4701,7 +4455,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -4754,7 +4507,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-nat",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -4762,7 +4514,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -4815,7 +4566,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-nat",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -4823,7 +4573,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -4876,7 +4625,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-nat",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -4884,7 +4632,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -4937,7 +4684,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-nat",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -4945,7 +4691,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -4998,7 +4743,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-nat",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -5006,7 +4750,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -5059,7 +4802,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-nat",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -5067,7 +4809,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [
@@ -5120,7 +4861,6 @@
             "test-type": "TestTypeBenchmark",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-nat",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -5128,7 +4868,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-pktgen",
                     "app-type": "TestAppPktgen",
                     "exec-cmd": [

--- a/test/framework/main/stability.json
+++ b/test/framework/main/stability.json
@@ -9,7 +9,6 @@
             "/sys/devices/system/node:/sys/devices/system/node",
             "/dev:/dev"
         ],
-        "docker-port": 2375,
         "pktgen-port": 22022
     },
     "tests": [
@@ -19,7 +18,6 @@
             "test-type": "TestTypeScenario",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-test1",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -27,7 +25,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-test1",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -42,7 +39,6 @@
             "test-type": "TestTypeScenario",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-test-merge",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -50,7 +46,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-test-merge",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -65,7 +60,6 @@
             "test-type": "TestTypeScenario",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-test-split",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -73,7 +67,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-test-split",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -88,7 +81,6 @@
             "test-type": "TestTypeScenario",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-test-separate",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -96,7 +88,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-test-separate",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -111,7 +102,6 @@
             "test-type": "TestTypeScenario",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-test-partition",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -119,7 +109,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-test-partition",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -134,7 +123,6 @@
             "test-type": "TestTypeScenario",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-test-handle2",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -142,7 +130,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-test-handle2",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -157,7 +144,6 @@
             "test-type": "TestTypeScenario",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-test-cksum",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -165,7 +151,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-test-cksum",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -180,7 +165,6 @@
             "test-type": "TestTypeScenario",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-test-cksum",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -188,7 +172,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-test-cksum",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -203,7 +186,6 @@
             "test-type": "TestTypeScenario",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-test-cksum",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -211,7 +193,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-test-cksum",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -226,7 +207,6 @@
             "test-type": "TestTypeScenario",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-test-cksum",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -234,7 +214,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-test-cksum",
                     "app-type": "TestAppGo",
                     "exec-cmd": [

--- a/test/framework/main/stability_VM.json
+++ b/test/framework/main/stability_VM.json
@@ -9,7 +9,6 @@
             "/sys/devices/system/node:/sys/devices/system/node",
             "/dev:/dev"
         ],
-        "docker-port": 2375,
         "pktgen-port": 22022
     },
     "tests": [
@@ -19,7 +18,6 @@
             "test-type": "TestTypeScenario",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-test1",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -27,7 +25,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-test1",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -42,7 +39,6 @@
             "test-type": "TestTypeScenario",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-test-merge",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -50,7 +46,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-test-merge",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -65,7 +60,6 @@
             "test-type": "TestTypeScenario",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-test-split",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -73,7 +67,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-test-split",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -88,7 +81,6 @@
             "test-type": "TestTypeScenario",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-test-separate",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -96,7 +88,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-test-separate",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -111,7 +102,6 @@
             "test-type": "TestTypeScenario",
             "test-apps": [
                 {
-                    "host-name": "hostname1",
                     "image-name": "nff-go-test-partition",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
@@ -119,7 +109,6 @@
                     ]
                 },
                 {
-                    "host-name": "hostname2",
                     "image-name": "nff-go-test-partition",
                     "app-type": "TestAppGo",
                     "exec-cmd": [

--- a/test/framework/main/tf.go
+++ b/test/framework/main/tf.go
@@ -41,5 +41,6 @@ func main() {
 	}
 
 	// Start test execution
-	config.RunAllTests(directory)
+	status := config.RunAllTests(directory)
+	os.Exit(status)
 }

--- a/test/framework/testsuite.go
+++ b/test/framework/testsuite.go
@@ -168,10 +168,10 @@ func (config *TestsuiteConfig) executeOneTest(index int, logdir string,
 }
 
 // RunAllTests launches all tests.
-func (config *TestsuiteConfig) RunAllTests(logdir string) {
+func (config *TestsuiteConfig) RunAllTests(logdir string) int {
 	report := StartReport(logdir)
 	if report == nil {
-		return
+		return 255
 	}
 
 	// Set up reaction to SIGINT (Ctrl-C)
@@ -200,6 +200,7 @@ func (config *TestsuiteConfig) RunAllTests(logdir string) {
 	LogInfo("TESTS EXECUTED:", totalTests)
 	LogInfo("PASSED:", passedTests)
 	LogInfo("FAILED:", failedTests)
+	return failedTests
 }
 
 func setAppStatusOnTimeout(testType TestType, apps []RunningApp) {

--- a/test/performance/Dockerfile
+++ b/test/performance/Dockerfile
@@ -1,8 +1,9 @@
-# Copyright 2017 Intel Corporation. 
+# Copyright 2017 Intel Corporation.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-FROM nff-go-base
+ARG USER_NAME
+FROM ${USER_NAME}/nff-go-base
 
 LABEL RUN docker run -it --privileged -v /sys/bus/pci/drivers:/sys/bus/pci/drivers -v /sys/kernel/mm/hugepages:/sys/kernel/mm/hugepages -v /sys/devices/system/node:/sys/devices/system/node -v /dev:/dev --name NAME -e NAME=NAME -e IMAGE=IMAGE IMAGE
 

--- a/test/stability/testCksum/.gitignore
+++ b/test/stability/testCksum/.gitignore
@@ -1,2 +1,2 @@
-main-test-checksum
+testCksum
 config.json

--- a/test/stability/testCksum/Dockerfile
+++ b/test/stability/testCksum/Dockerfile
@@ -2,7 +2,8 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-FROM nff-go-base
+ARG USER_NAME
+FROM ${USER_NAME}/nff-go-base
 
 LABEL RUN docker run -it --privileged -v /sys/bus/pci/drivers:/sys/bus/pci/drivers -v /sys/kernel/mm/hugepages:/sys/kernel/mm/hugepages -v /sys/devices/system/node:/sys/devices/system/node -v /dev:/dev --name NAME -e NAME=NAME -e IMAGE=IMAGE IMAGE
 

--- a/test/stability/testHandle/.gitignore
+++ b/test/stability/testHandle/.gitignore
@@ -1,1 +1,1 @@
-main-test-handle2
+testHandle

--- a/test/stability/testHandle/Dockerfile
+++ b/test/stability/testHandle/Dockerfile
@@ -1,8 +1,9 @@
-# Copyright 2017 Intel Corporation. 
+# Copyright 2017 Intel Corporation.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-FROM nff-go-base
+ARG USER_NAME
+FROM ${USER_NAME}/nff-go-base
 
 LABEL RUN docker run -it --privileged -v /sys/bus/pci/drivers:/sys/bus/pci/drivers -v /sys/kernel/mm/hugepages:/sys/kernel/mm/hugepages -v /sys/devices/system/node:/sys/devices/system/node -v /dev:/dev --name NAME -e NAME=NAME -e IMAGE=IMAGE IMAGE
 

--- a/test/stability/testMerge/.gitignore
+++ b/test/stability/testMerge/.gitignore
@@ -1,2 +1,2 @@
-main-test-merge
+testMerge
 config.json

--- a/test/stability/testMerge/Dockerfile
+++ b/test/stability/testMerge/Dockerfile
@@ -1,8 +1,9 @@
-# Copyright 2017 Intel Corporation. 
+# Copyright 2017 Intel Corporation.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-FROM nff-go-base
+ARG USER_NAME
+FROM ${USER_NAME}/nff-go-base
 
 LABEL RUN docker run -it --privileged -v /sys/bus/pci/drivers:/sys/bus/pci/drivers -v /sys/kernel/mm/hugepages:/sys/kernel/mm/hugepages -v /sys/devices/system/node:/sys/devices/system/node -v /dev:/dev --name NAME -e NAME=NAME -e IMAGE=IMAGE IMAGE
 

--- a/test/stability/testPartition/.gitignore
+++ b/test/stability/testPartition/.gitignore
@@ -1,2 +1,2 @@
-main-test-partition
+testPartition
 config.json

--- a/test/stability/testPartition/Dockerfile
+++ b/test/stability/testPartition/Dockerfile
@@ -1,8 +1,9 @@
-# Copyright 2017 Intel Corporation. 
+# Copyright 2017 Intel Corporation.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-FROM nff-go-base
+ARG USER_NAME
+FROM ${USER_NAME}/nff-go-base
 
 LABEL RUN docker run -it --privileged -v /sys/bus/pci/drivers:/sys/bus/pci/drivers -v /sys/kernel/mm/hugepages:/sys/kernel/mm/hugepages -v /sys/devices/system/node:/sys/devices/system/node -v /dev:/dev --name NAME -e NAME=NAME -e IMAGE=IMAGE IMAGE
 

--- a/test/stability/testResend/.gitignore
+++ b/test/stability/testResend/.gitignore
@@ -1,2 +1,2 @@
 config.json
-main-test-resend
+testResend

--- a/test/stability/testResend/Dockerfile
+++ b/test/stability/testResend/Dockerfile
@@ -1,8 +1,9 @@
-# Copyright 2017 Intel Corporation. 
+# Copyright 2017 Intel Corporation.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-FROM nff-go-base
+ARG USER_NAME
+FROM ${USER_NAME}/nff-go-base
 
 LABEL RUN docker run -it --privileged -v /sys/bus/pci/drivers:/sys/bus/pci/drivers -v /sys/kernel/mm/hugepages:/sys/kernel/mm/hugepages -v /sys/devices/system/node:/sys/devices/system/node -v /dev:/dev --name NAME -e NAME=NAME -e IMAGE=IMAGE IMAGE
 

--- a/test/stability/testSeparate/.gitignore
+++ b/test/stability/testSeparate/.gitignore
@@ -1,2 +1,2 @@
 config.json
-main-test-separate
+testSeparate

--- a/test/stability/testSeparate/Dockerfile
+++ b/test/stability/testSeparate/Dockerfile
@@ -1,8 +1,9 @@
-# Copyright 2017 Intel Corporation. 
+# Copyright 2017 Intel Corporation.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-FROM nff-go-base
+ARG USER_NAME
+FROM ${USER_NAME}/nff-go-base
 
 LABEL RUN docker run -it --privileged -v /sys/bus/pci/drivers:/sys/bus/pci/drivers -v /sys/kernel/mm/hugepages:/sys/kernel/mm/hugepages -v /sys/devices/system/node:/sys/devices/system/node -v /dev:/dev --name NAME -e NAME=NAME -e IMAGE=IMAGE IMAGE
 

--- a/test/stability/testSplit/.gitignore
+++ b/test/stability/testSplit/.gitignore
@@ -1,2 +1,2 @@
 config.json
-main-test-split
+testSplit

--- a/test/stability/testSplit/Dockerfile
+++ b/test/stability/testSplit/Dockerfile
@@ -1,8 +1,9 @@
-# Copyright 2017 Intel Corporation. 
+# Copyright 2017 Intel Corporation.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-FROM nff-go-base
+ARG USER_NAME
+FROM ${USER_NAME}/nff-go-base
 
 LABEL RUN docker run -it --privileged -v /sys/bus/pci/drivers:/sys/bus/pci/drivers -v /sys/kernel/mm/hugepages:/sys/kernel/mm/hugepages -v /sys/devices/system/node:/sys/devices/system/node -v /dev:/dev --name NAME -e NAME=NAME -e IMAGE=IMAGE IMAGE
 

--- a/test/stash/Dockerfile
+++ b/test/stash/Dockerfile
@@ -2,7 +2,8 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-FROM nff-go-base
+ARG USER_NAME
+FROM ${USER_NAME}/nff-go-base
 
 LABEL RUN docker run -it --privileged -v /sys/bus/pci/drivers:/sys/bus/pci/drivers -v /sys/kernel/mm/hugepages:/sys/kernel/mm/hugepages -v /sys/devices/system/node:/sys/devices/system/node -v /dev:/dev --name NAME -e NAME=NAME -e IMAGE=IMAGE IMAGE
 

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -54,9 +54,8 @@ chmod +x ~/scripts.sh
 echo . ~/scripts.sh >> .bashrc
 
 echo Downloading and building NFF-GO
-go get github.com/pkg/errors
 go get -d -v github.com/intel-go/nff-go
-(cd \"$GOPATH\"/src/github.com/intel-go/nff-go; git checkout develop; make -j4)
+(cd \"$GOPATH\"/src/github.com/intel-go/nff-go; git checkout develop; ./scripts/get-depends.sh; make -j4)
 
 echo Setting up 1024 huge pages
 sudo sh -c 'echo 1024 > /sys/devices/system/node/node0/hugepages/hugepages-2048kB/nr_hugepages'

--- a/vagrant/scripts.sh
+++ b/vagrant/scripts.sh
@@ -1,8 +1,8 @@
 export GOPATH="$HOME"/go
 export GOROOT=/opt/go
-export NFF-GO="$GOPATH"/src/github.com/intel-go/nff-go
+export NFF_GO="$GOPATH"/src/github.com/intel-go/nff-go
 export PATH="$GOPATH"/bin:"$GOROOT"/bin:"$PATH"
-export NFF-GO_CARDS="00:08.0 00:09.0"
+export NFF_GO_CARDS="00:08.0 00:09.0"
 export DISTRO=$(lsb_release -i | cut -d: -f2 | sed s/'^\t'//)
 if [ $DISTRO == Ubuntu ]; then
     export CARD1=enp0s8
@@ -16,20 +16,20 @@ fi
 bindports ()
 {
     sudo modprobe uio
-    sudo insmod "$NFF-GO"/dpdk/dpdk-17.08/x86_64-native-linuxapp-gcc/kmod/igb_uio.ko
-    sudo "$NFF-GO"/dpdk/dpdk-17.08/usertools/dpdk-devbind.py --bind=igb_uio $NFF-GO_CARDS
+    sudo insmod "$NFF_GO"/dpdk/dpdk-17.08/x86_64-native-linuxapp-gcc/kmod/igb_uio.ko
+    sudo "$NFF_GO"/dpdk/dpdk-17.08/usertools/dpdk-devbind.py --bind=igb_uio $NFF_GO_CARDS
 }
 
 # Bind ports to Linux kernel driver
 unbindports ()
 {
-    sudo "$NFF-GO"/dpdk/dpdk-17.08/usertools/dpdk-devbind.py --bind=e1000 $NFF-GO_CARDS
+    sudo "$NFF_GO"/dpdk/dpdk-17.08/usertools/dpdk-devbind.py --bind=e1000 $NFF_GO_CARDS
 }
 
 # Run pktgen
 runpktgen ()
 {
-    (cd "$NFF-GO"/dpdk; sudo ./pktgen -c 0xff -n 4 -- -P -m "[1:2].0, [3:4].1" -T)
+    (cd "$NFF_GO"/dpdk; sudo ./pktgen -c 0xff -n 4 -- -P -m "[1:2].0, [3:4].1" -T)
     rc=$?; if [[ $rc == 0 ]]; then reset; fi
 }
 
@@ -60,7 +60,7 @@ natclient ()
 # client (private network).
 natsetup ()
 {
-    export NFF-GO_CARDS="00:08.0 00:0a.0"
+    export NFF_GO_CARDS="00:08.0 00:0a.0"
     if [ $DISTRO == Ubuntu ]; then
         export CARD1=enp0s9
         export CARD2=enp0s16


### PR DESCRIPTION
- Changed YANFF_HOSTS format to comma separated list host1:port,host2:port.
- Removed host-name and docker-port from test config files. Now they
  have to be specified on command line.
- Added environment variables with DPDK and Pktgen archive
  locations. Now it is possible to download them once and use file://
  URLs instead of downloading them every time.
- Made yanff-base image with username prefix too. This allows parallel
  work for multiple users on the same host.
- Fixed renaming artefacts.
- Fixed dependencies to build NFF-Go.
- Added optional docker image prefix.
- Added non-zero return status if some tests failed.