### PR TITLE
Changed default DPDK log level in tests to 0

### DIFF
--- a/examples/nat/main/nat.go
+++ b/examples/nat/main/nat.go
@@ -28,6 +28,7 @@ func main() {
 	configFile := flag.String("config", "config.json", "Specify config file name")
 	flag.BoolVar(&nat.CalculateChecksum, "csum", true, "Specify whether to calculate checksums in modified packets")
 	flag.BoolVar(&nat.HWTXChecksum, "hwcsum", true, "Specify whether to use hardware offloading for checksums calculation (requires -csum)")
+	dpdkLogLevel := flag.String("dpdk", "--log-level=0", "Passes an arbitrary argument to dpdk EAL")
 	flag.Parse()
 
 	// Set up reaction to SIGINT (Ctrl-C)
@@ -41,6 +42,7 @@ func main() {
 	nffgoconfig := flow.Config{
 		CPUList:      *cores,
 		HWTXChecksum: nat.HWTXChecksum,
+		DPDKArgs: []string{ *dpdkLogLevel },
 	}
 
 	CheckFatal(flow.SystemInit(&nffgoconfig))

--- a/test/framework/testsuite.go
+++ b/test/framework/testsuite.go
@@ -200,7 +200,12 @@ func (config *TestsuiteConfig) RunAllTests(logdir string) int {
 	LogInfo("TESTS EXECUTED:", totalTests)
 	LogInfo("PASSED:", passedTests)
 	LogInfo("FAILED:", failedTests)
-	return failedTests
+
+	if failedTests > 0 {
+		return 100 + failedTests
+	} else {
+		return 0
+	}
 }
 
 func setAppStatusOnTimeout(testType TestType, apps []RunningApp) {

--- a/test/stability/testCksum/testCksum.go
+++ b/test/stability/testCksum/testCksum.go
@@ -75,6 +75,7 @@ var (
 	randomL4     = false
 	l4type       int
 	packetLength int
+	dpdkLogLevel *string
 )
 
 func main() {
@@ -90,6 +91,7 @@ func main() {
 	flag.BoolVar(&useIPv6, "ipv6", false, "Generate IPv6 packets")
 	flag.IntVar(&packetLength, "size", 0, "Specify length of packets to be generated")
 	flag.Uint64Var(&totalPackets, "number", 10, "Number of packets to send")
+	dpdkLogLevel = flag.String("dpdk", "--log-level=0", "Passes an arbitrary argument to dpdk EAL")
 	flag.Parse()
 
 	if !useIPv4 && !useIPv6 {
@@ -145,6 +147,7 @@ func executeTest(testScenario uint) error {
 	// Init NFF-GO system at 16 available cores
 	config := flow.Config{
 		HWTXChecksum: hwol,
+		DPDKArgs: []string{ *dpdkLogLevel },
 	}
 	if err := flow.SystemInit(&config); err != nil { return err }
 

--- a/test/stability/testHandle/testHandle.go
+++ b/test/stability/testHandle/testHandle.go
@@ -70,6 +70,7 @@ var (
 
 	outport uint
 	inport  uint
+	dpdkLogLevel *string
 
 	rulesConfig = "test-handle-l3rules.conf"
 )
@@ -82,6 +83,7 @@ func main() {
 	flag.UintVar(&inport, "inport", 0, "port for receiver")
 	flag.Uint64Var(&totalPackets, "number", totalPackets, "total number of packets to receive by test")
 	flag.DurationVar(&T, "timeout", T, "test start delay, needed to stabilize speed. Packets sent during timeout do not affect test result")
+	dpdkLogLevel = flag.String("dpdk", "--log-level=0", "Passes an arbitrary argument to dpdk EAL")
 	flag.Parse()
 
 	if err := executeTest(testScenario); err != nil {
@@ -94,7 +96,9 @@ func executeTest(testScenario uint) error {
 		return errors.New("testScenario should be in interval [0, 3]")
 	}
 	// Init NFF-GO system
-	config := flow.Config{}
+	config := flow.Config{
+		DPDKArgs: []string{ *dpdkLogLevel },
+	}
 	if err := flow.SystemInit(&config); err != nil {
 		return err
 	}

--- a/test/stability/testMerge/testMerge.go
+++ b/test/stability/testMerge/testMerge.go
@@ -65,6 +65,7 @@ var (
 	outport2 uint
 	inport1  uint
 	inport2  uint
+	dpdkLogLevel *string
 
 	fixMACAddrs  func(*packet.Packet, flow.UserContext)
 	fixMACAddrs1 func(*packet.Packet, flow.UserContext)
@@ -84,6 +85,7 @@ func main() {
 	flag.DurationVar(&T, "timeout", T, "test start delay, needed to stabilize speed. Packets sent during timeout do not affect test result")
 	configFile := flag.String("config", "", "Specify json config file name (mandatory for VM)")
 	target := flag.String("target", "", "Target host name from config file (mandatory for VM)")
+	dpdkLogLevel = flag.String("dpdk", "--log-level=0", "Passes an arbitrary argument to dpdk EAL")
 	flag.Parse()
 	if err := executeTest(*configFile, *target, testScenario); err != nil {
 		fmt.Printf("fail: %+v\n", err)
@@ -95,7 +97,9 @@ func executeTest(configFile, target string, testScenario uint) error {
 		return errors.New("testScenario should be in interval [0, 3]")
 	}
 	// Init NFF-GO system
-	config := flow.Config{}
+	config := flow.Config{
+		DPDKArgs: []string{ *dpdkLogLevel },
+	}
 	if err := flow.SystemInit(&config); err != nil { return err }
 	stabilityCommon.InitCommonState(configFile, target)
 

--- a/test/stability/testPartition/testPartition.go
+++ b/test/stability/testPartition/testPartition.go
@@ -66,6 +66,7 @@ var (
 	outport2 uint
 	inport1  uint
 	inport2  uint
+	dpdkLogLevel *string
 
 	fixMACAddrs  func(*packet.Packet, flow.UserContext)
 	fixMACAddrs1 func(*packet.Packet, flow.UserContext)
@@ -85,6 +86,7 @@ func main() {
 	flag.DurationVar(&T, "timeout", T, "test start delay, needed to stabilize speed. Packets sent during timeout do not affect test result")
 	configFile := flag.String("config", "", "Specify json config file name (mandatory for VM)")
 	target := flag.String("target", "", "Target host name from config file (mandatory for VM)")
+	dpdkLogLevel = flag.String("dpdk", "--log-level=0", "Passes an arbitrary argument to dpdk EAL")
 	flag.Parse()
 
 	if err := executeTest(*configFile, *target, testScenario); err != nil {
@@ -97,7 +99,9 @@ func executeTest(configFile, target string, testScenario uint) error {
 		return errors.New("testScenario should be in interval [0, 3]")
 	}
 	// Init NFF-GO system
-	config := flow.Config{}
+	config := flow.Config{
+		DPDKArgs: []string{ *dpdkLogLevel },
+	}
 	if err := flow.SystemInit(&config); err != nil { return err }
 	stabilityCommon.InitCommonState(configFile, target)
 	fixMACAddrs = stabilityCommon.ModifyPacket[outport1].(func(*packet.Packet, flow.UserContext))

--- a/test/stability/testResend/testResend.go
+++ b/test/stability/testResend/testResend.go
@@ -57,8 +57,7 @@ var (
 
 	outport uint
 	inport  uint
-
-	cores uint
+	dpdkLogLevel *string
 
 	fixMACAddrs  func(*packet.Packet, flow.UserContext)
 	fixMACAddrs1 func(*packet.Packet, flow.UserContext)
@@ -74,6 +73,7 @@ func main() {
 	flag.DurationVar(&T, "timeout", T, "test start timeout, time to stabilize speed. Packets sent during timeout do not affect test result")
 	configFile := flag.String("config", "", "Specify json config file name (mandatory for VM)")
 	target := flag.String("target", "", "Target host name from config file (mandatory for VM)")
+	dpdkLogLevel = flag.String("dpdk", "--log-level=0", "Passes an arbitrary argument to dpdk EAL")
 	flag.Parse()
 	if err := executeTest(*configFile, *target, testScenario); err != nil {
 		fmt.Printf("fail: %+v\n", err)
@@ -85,7 +85,9 @@ func executeTest(configFile, target string, testScenario uint) error {
 		return errors.New("testScenario should be in interval [0, 3]")
 	}
 	// Init NFF-GO system
-	config := flow.Config{}
+	config := flow.Config{
+		DPDKArgs: []string{ *dpdkLogLevel },
+	}
 
 	if err := flow.SystemInit(&config); err != nil { return err }
 

--- a/test/stability/testSeparate/testSeparate.go
+++ b/test/stability/testSeparate/testSeparate.go
@@ -73,6 +73,7 @@ var (
 	outport2 uint
 	inport1  uint
 	inport2  uint
+	dpdkLogLevel *string
 
 	fixMACAddrs  func(*packet.Packet, flow.UserContext)
 	fixMACAddrs1 func(*packet.Packet, flow.UserContext)
@@ -94,6 +95,7 @@ func main() {
 	flag.DurationVar(&T, "timeout", T, "test start delay, needed to stabilize speed. Packets sent during timeout do not affect test result")
 	configFile := flag.String("config", "", "Specify json config file name (mandatory for VM)")
 	target := flag.String("target", "", "Target host name from config file (mandatory for VM)")
+	dpdkLogLevel = flag.String("dpdk", "--log-level=0", "Passes an arbitrary argument to dpdk EAL")
 	flag.Parse()
 	if err := executeTest(*configFile, *target, testScenario); err != nil {
 		fmt.Printf("fail: %+v\n", err)
@@ -105,7 +107,9 @@ func executeTest(configFile, target string, testScenario uint) error {
 		return errors.New("testScenario should be in interval [0, 3]")
 	}
 	// Init NFF-GO system
-	config := flow.Config{}
+	config := flow.Config{
+		DPDKArgs: []string{ *dpdkLogLevel },
+	}
 	if err := flow.SystemInit(&config); err != nil { return err }
 	stabilityCommon.InitCommonState(configFile, target)
 

--- a/test/stability/testSplit/testSplit.go
+++ b/test/stability/testSplit/testSplit.go
@@ -80,6 +80,7 @@ var (
 	outport2 uint
 	inport1  uint
 	inport2  uint
+	dpdkLogLevel *string
 
 	fixMACAddrs  func(*packet.Packet, flow.UserContext)
 	fixMACAddrs1 func(*packet.Packet, flow.UserContext)
@@ -103,6 +104,7 @@ func main() {
 	configFile := flag.String("config", "", "Specify json config file name (mandatory for VM)")
 	target := flag.String("target", "", "Target host name from config file (mandatory for VM)")
 	filename = flag.String("FILE", rulesString, "file with split rules in .conf format. If you change default port numbers, please, provide modified rules file too")
+	dpdkLogLevel = flag.String("dpdk", "--log-level=0", "Passes an arbitrary argument to dpdk EAL")
 	flag.Parse()
 	if err := executeTest(*configFile, *target, testScenario); err != nil {
 		fmt.Printf("fail: %+v\n", err)
@@ -114,7 +116,9 @@ func executeTest(configFile, target string, testScenario uint) error {
 		return errors.New("testScenario should be in interval [0, 3]")
 	}
 	// Init NFF-GO system
-	config := flow.Config{}
+	config := flow.Config{
+		DPDKArgs: []string{ *dpdkLogLevel },
+	}
 	if err := flow.SystemInit(&config); err != nil {
 		return err
 	}

--- a/vagrant/scripts.sh
+++ b/vagrant/scripts.sh
@@ -147,20 +147,19 @@ setupdocker ()
         sudo apt-get install -y docker-ce
         sudo gpasswd -a ubuntu docker
         sudo sed -i -e 's,ExecStart=/usr/bin/dockerd -H fd://,ExecStart=/usr/bin/dockerd,' /lib/systemd/system/docker.service
-    sudo sh -c 'cat <<EOF > /etc/docker/daemon.json
-{
-    "hosts": ["unix:///var/run/docker.sock", "tcp://0.0.0.0:2375", "fd://"]
-}
-EOF'
     elif [ $DISTRO == Fedora ]; then
         sudo dnf config-manager --add-repo https://download.docker.com/linux/fedora/docker-ce.repo
         sudo dnf -y install docker-ce
         sudo gpasswd -a vagrant docker
         sudo firewall-cmd --permanent --add-port=2375/tcp
         sudo firewall-cmd --add-port=2375/tcp
-        sudo sed -i -e 's,ExecStart=/usr/bin/dockerd,ExecStart=/usr/bin/dockerd -H unix:///var/run/docker.sock -H tcp://0.0.0.0:2375,' /lib/systemd/system/docker.service
     fi
 
+    sudo sh -c 'cat <<EOF > /etc/docker/daemon.json
+{
+    "hosts": ["unix:///var/run/docker.sock", "tcp://0.0.0.0:2375"]
+}
+EOF'
     sudo systemctl enable docker.service
     sudo systemctl daemon-reload
     sudo systemctl restart docker.service


### PR DESCRIPTION
- This is possibly a workaround for docker bugs with high output
  applications.
- Docker config via daemon.json made common for Ubuntu and Fedora
- Add 100 to number of failed tests for exit status. It allows quick
  diagnostics of error status in TeamCity.