### PR TITLE
Support VLAN-tagged packets in testCksum

### DIFF
--- a/packet/packet.go
+++ b/packet/packet.go
@@ -260,12 +260,12 @@ func (packet *Packet) GetIPv6NoCheck() *IPv6Hdr {
 
 // ParseL4ForIPv4 set L4 to start of L4 header, if L3 protocol is IPv4.
 func (packet *Packet) ParseL4ForIPv4() {
-	packet.L4 = unsafe.Pointer(uintptr(packet.unparsed()) + uintptr((packet.GetIPv4NoCheck().VersionIhl&0x0f)<<2))
+	packet.L4 = unsafe.Pointer(uintptr(packet.L3) + uintptr((packet.GetIPv4NoCheck().VersionIhl&0x0f)<<2))
 }
 
 // ParseL4ForIPv6 set L4 to start of L4 header, if L3 protocol is IPv6.
 func (packet *Packet) ParseL4ForIPv6() {
-	packet.L4 = unsafe.Pointer(uintptr(packet.unparsed()) + uintptr(IPv6Len))
+	packet.L4 = unsafe.Pointer(uintptr(packet.L3) + uintptr(IPv6Len))
 }
 
 // GetTCPForIPv4 ensures if L4 type is TCP and cast L4 pointer to TCPHdr type.

--- a/test/framework/main/stability.json
+++ b/test/framework/main/stability.json
@@ -147,7 +147,7 @@
                     "image-name": "nff-go-test-cksum",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
-                        "./testCksum", "-testScenario=1", "-ipv4", "-tcp", "-number=1000000", "-inport=0", "-outport=1"
+                        "./testCksum", "-testScenario=1", "-hwol", "-ipv4", "-tcp", "-number=1000000", "-inport=0", "-outport=1"
                     ]
                 },
                 {
@@ -168,7 +168,7 @@
                     "image-name": "nff-go-test-cksum",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
-                        "./testCksum", "-testScenario=1", "-ipv4", "-udp", "-number=1000000", "-inport=0", "-outport=1"
+                        "./testCksum", "-testScenario=1", "-hwol", "-ipv4", "-udp", "-number=1000000", "-inport=0", "-outport=1"
                     ]
                 },
                 {
@@ -189,7 +189,7 @@
                     "image-name": "nff-go-test-cksum",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
-                        "./testCksum", "-testScenario=1", "-ipv6", "-tcp", "-number=1000000", "-inport=0", "-outport=1"
+                        "./testCksum", "-testScenario=1", "-hwol", "-ipv6", "-tcp", "-number=1000000", "-inport=0", "-outport=1"
                     ]
                 },
                 {
@@ -210,7 +210,7 @@
                     "image-name": "nff-go-test-cksum",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
-                        "./testCksum", "-testScenario=1", "-ipv6", "-udp", "-number=1000000", "-inport=0", "-outport=1"
+                        "./testCksum", "-testScenario=1", "-hwol", "-ipv6", "-udp", "-number=1000000", "-inport=0", "-outport=1"
                     ]
                 },
                 {
@@ -218,6 +218,132 @@
                     "app-type": "TestAppGo",
                     "exec-cmd": [
                         "./testCksum", "-testScenario=2", "-hwol", "-inport=1", "-outport=0"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "cksums_ipv4_icmp",
+            "test-time": 60000000000,
+            "test-type": "TestTypeScenario",
+            "test-apps": [
+                {
+                    "image-name": "nff-go-test-cksum",
+                    "app-type": "TestAppGo",
+                    "exec-cmd": [
+                        "./testCksum", "-testScenario=1", "-hwol", "-ipv4", "-icmp", "-number=1000000", "-inport=0", "-outport=1"
+                    ]
+                },
+                {
+                    "image-name": "nff-go-test-cksum",
+                    "app-type": "TestAppGo",
+                    "exec-cmd": [
+                        "./testCksum", "-testScenario=2", "-hwol", "-vlan", "-inport=1", "-outport=0"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "cksums_ipv4_tcp_vlan",
+            "test-time": 60000000000,
+            "test-type": "TestTypeScenario",
+            "test-apps": [
+                {
+                    "image-name": "nff-go-test-cksum",
+                    "app-type": "TestAppGo",
+                    "exec-cmd": [
+                        "./testCksum", "-testScenario=1", "-hwol", "-ipv4", "-tcp", "-vlan",  "-number=1000000", "-inport=0", "-outport=1"
+                    ]
+                },
+                {
+                    "image-name": "nff-go-test-cksum",
+                    "app-type": "TestAppGo",
+                    "exec-cmd": [
+                        "./testCksum", "-testScenario=2", "-hwol", "-vlan", "-inport=1", "-outport=0"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "cksums_ipv4_udp_vlan",
+            "test-time": 60000000000,
+            "test-type": "TestTypeScenario",
+            "test-apps": [
+                {
+                    "image-name": "nff-go-test-cksum",
+                    "app-type": "TestAppGo",
+                    "exec-cmd": [
+                        "./testCksum", "-testScenario=1", "-hwol", "-ipv4", "-udp", "-vlan", "-number=1000000", "-inport=0", "-outport=1"
+                    ]
+                },
+                {
+                    "image-name": "nff-go-test-cksum",
+                    "app-type": "TestAppGo",
+                    "exec-cmd": [
+                        "./testCksum", "-testScenario=2", "-hwol", "-vlan", "-inport=1", "-outport=0"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "cksums_ipv6_tcp_vlan",
+            "test-time": 60000000000,
+            "test-type": "TestTypeScenario",
+            "test-apps": [
+                {
+                    "image-name": "nff-go-test-cksum",
+                    "app-type": "TestAppGo",
+                    "exec-cmd": [
+                        "./testCksum", "-testScenario=1", "-hwol", "-ipv6", "-tcp", "-vlan", "-number=1000000", "-inport=0", "-outport=1"
+                    ]
+                },
+                {
+                    "image-name": "nff-go-test-cksum",
+                    "app-type": "TestAppGo",
+                    "exec-cmd": [
+                        "./testCksum", "-testScenario=2", "-hwol", "-vlan", "-inport=1", "-outport=0"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "cksums_ipv6_udp_vlan",
+            "test-time": 60000000000,
+            "test-type": "TestTypeScenario",
+            "test-apps": [
+                {
+                    "image-name": "nff-go-test-cksum",
+                    "app-type": "TestAppGo",
+                    "exec-cmd": [
+                        "./testCksum", "-testScenario=1", "-hwol", "-ipv6", "-udp", "-vlan", "-number=1000000", "-inport=0", "-outport=1"
+                    ]
+                },
+                {
+                    "image-name": "nff-go-test-cksum",
+                    "app-type": "TestAppGo",
+                    "exec-cmd": [
+                        "./testCksum", "-testScenario=2", "-hwol", "-vlan", "-inport=1", "-outport=0"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "cksums_ipv4_icmp_vlan",
+            "test-time": 60000000000,
+            "test-type": "TestTypeScenario",
+            "test-apps": [
+                {
+                    "image-name": "nff-go-test-cksum",
+                    "app-type": "TestAppGo",
+                    "exec-cmd": [
+                        "./testCksum", "-testScenario=1", "-hwol", "-ipv4", "-icmp", "-vlan",  "-number=1000000", "-inport=0", "-outport=1"
+                    ]
+                },
+                {
+                    "image-name": "nff-go-test-cksum",
+                    "app-type": "TestAppGo",
+                    "exec-cmd": [
+                        "./testCksum", "-testScenario=2", "-hwol", "-vlan", "-inport=1", "-outport=0"
                     ]
                 }
             ]

--- a/test/stability/stabilityCommon/common.go
+++ b/test/stability/stabilityCommon/common.go
@@ -60,7 +60,7 @@ func ShouldBeSkippedAllExcept(pkt *packet.Packet, ipVersion uint, protocol Proto
 	var pktTCP *packet.TCPHdr
 	var pktUDP *packet.UDPHdr
 	var pktICMP *packet.ICMPHdr
-	pktIPv4, pktIPv6, _ := pkt.ParseAllKnownL3()
+	pktIPv4, pktIPv6, _ := pkt.ParseAllKnownL3CheckVLAN()
 	if (ipVersion == 0 || ipVersion == 4) && pktIPv4 != nil {
 		pktTCP, pktUDP, pktICMP = pkt.ParseAllKnownL4ForIPv4()
 	} else if (ipVersion == 0 || ipVersion == 6) && pktIPv6 != nil {


### PR DESCRIPTION
- Add ParseDataCheckVLAN function
- ParseL4ForIPv4, ParseL4ForIPv6 work correctly with
VLAN-tagged packets