### PR TITLE
Added dynamic RSS scaling.

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -132,6 +132,7 @@ const (
 	PcapWriteFail
 	InvalidCPURangeErr
 	SetAffinityErr
+	MultipleReceivePort
 )
 
 // NFError is error type returned by nff-go functions

--- a/examples/gopacket_parser_example.go
+++ b/examples/gopacket_parser_example.go
@@ -15,10 +15,8 @@ import (
 )
 
 var (
-	printOn bool
-
-	inport1     uint
-	inport2     uint
+	printOn     bool
+	inport      uint
 	outport1    uint
 	outport2    uint
 	noscheduler bool
@@ -36,8 +34,7 @@ func main() {
 	flag.BoolVar(&printOn, "print", false, "enable print of parsed layers")
 	flag.UintVar(&outport1, "outport1", 1, "port for 1st sender")
 	flag.UintVar(&outport2, "outport2", 1, "port for 2nd sender")
-	flag.UintVar(&inport1, "inport1", 0, "port for 1st receiver")
-	flag.UintVar(&inport2, "inport2", 0, "port for 2nd receiver")
+	flag.UintVar(&inport, "inport", 0, "port for receiver")
 	flag.BoolVar(&noscheduler, "no-scheduler", false, "disable scheduler")
 	flag.Parse()
 
@@ -49,12 +46,7 @@ func main() {
 	flow.SystemInit(&config)
 
 	// Receive packets from zero port. One queue per receive will be added automatically.
-	firstFlow0, err := flow.SetReceiver(uint8(inport1))
-	CheckFatal(err)
-	firstFlow1, err := flow.SetReceiver(uint8(inport2))
-	CheckFatal(err)
-
-	firstFlow, err := flow.SetMerger(firstFlow0, firstFlow1)
+	firstFlow, err := flow.SetReceiver(uint8(inport))
 	CheckFatal(err)
 
 	var ctx gopacketContext

--- a/low/low.h
+++ b/low/low.h
@@ -22,6 +22,8 @@
 #define RX_RING_SIZE 128
 #define TX_RING_SIZE 512
 
+#define APP_RETA_SIZE_MAX (ETH_RSS_RETA_SIZE_512 / RTE_RETA_GROUP_SIZE)
+
 // #define DEBUG
 // #define REASSEMBLY
 
@@ -67,6 +69,11 @@ static int kni_config_network_interface(uint8_t port_id, uint8_t if_up);
 
 uint32_t BURST_SIZE;
 
+struct cPort {
+	uint8_t PortId;
+	uint8_t QueuesNumber;
+};
+
 void initCPUSet(int coreId, cpu_set_t* cpuset) {
 	CPU_ZERO(cpuset);
 	CPU_SET(coreId, cpuset);
@@ -106,11 +113,64 @@ void create_kni(uint8_t port, uint8_t core, char *name, struct rte_mempool *mbuf
 	}
 }
 
+int checkRSSPacketCount(struct cPort *port) {
+	return rte_eth_rx_queue_count(port->PortId, port->QueuesNumber-1);
+}
+
+bool changeRSSReta(struct cPort *port, bool increment) {
+	struct rte_eth_dev_info dev_info;
+	memset(&dev_info, 0, sizeof(dev_info));
+	rte_eth_dev_info_get(port->PortId, &dev_info);
+
+	struct rte_eth_rss_reta_entry64 reta_conf[APP_RETA_SIZE_MAX];
+	memset(reta_conf, 0, sizeof(reta_conf));
+
+	// This is required, hanging without this
+	for (int i = 0; i < dev_info.reta_size / RTE_RETA_GROUP_SIZE; i++) {
+		reta_conf[i].mask = UINT64_MAX;
+	}
+
+	if (increment) {
+		if (port->QueuesNumber == dev_info.max_rx_queues) {
+			return false;
+		}
+		port->QueuesNumber++;
+	} else {
+		port->QueuesNumber--;
+	}
+
+        rte_eth_dev_rss_reta_query(port->PortId, reta_conf, dev_info.reta_size);
+
+	// http://dpdk.org/doc/api/examples_2ip_pipeline_2init_8c-example.html#a27
+	for (int i = 0; i < dev_info.reta_size / RTE_RETA_GROUP_SIZE; i++) {
+		for (int j = 0; j < RTE_RETA_GROUP_SIZE; j++) {
+			reta_conf[i].reta[j] = j % port->QueuesNumber;
+		}
+	}
+	rte_eth_dev_rss_reta_update(port->PortId, reta_conf, dev_info.reta_size);
+	return true;
+	// TODO we don't start or stop queues here. Is it right?
+}
+
 // Initializes a given port using global settings and with the RX buffers
 // coming from the mbuf_pool passed as a parameter.
-int port_init(uint8_t port, uint16_t receiveQueuesNumber, uint16_t sendQueuesNumber, struct rte_mempool *mbuf_pool,
-    struct ether_addr* addr, bool hwtxchecksum) {
-	const uint16_t rx_rings = receiveQueuesNumber, tx_rings = sendQueuesNumber;
+int port_init(uint8_t port, bool willReceive, uint16_t sendQueuesNumber, struct rte_mempool *mbuf_pool, struct ether_addr* addr, bool hwtxchecksum) {
+	uint16_t rx_rings, tx_rings = sendQueuesNumber;
+
+        struct rte_eth_dev_info dev_info;
+        memset(&dev_info, 0, sizeof(dev_info));
+        rte_eth_dev_info_get(port, &dev_info);
+
+	if (willReceive) {
+		// TODO Investigate this
+		if (dev_info.max_rx_queues > 16) {
+			rx_rings = 16;
+		} else {
+			rx_rings = dev_info.max_rx_queues;
+		}
+	} else {
+		rx_rings = 0;
+	}
 	int retval;
 	uint16_t q;
 
@@ -138,9 +198,6 @@ int port_init(uint8_t port, uint16_t receiveQueuesNumber, uint16_t sendQueuesNum
 			return retval;
 	}
 
-	struct rte_eth_dev_info dev_info;
-	memset(&dev_info, 0, sizeof(dev_info));
-	rte_eth_dev_info_get(port, &dev_info);
 	if (hwtxchecksum) {
 		/* Default TX settings are to disable offload operations, need to fix it */
 		dev_info.default_txconf.txq_flags = 0;
@@ -164,6 +221,17 @@ int port_init(uint8_t port, uint16_t receiveQueuesNumber, uint16_t sendQueuesNum
 
 	/* Enable RX in promiscuous mode for the Ethernet device. */
 	rte_eth_promiscuous_enable(port);
+
+	// Not to use .rx_deferred_start = 0 in custom configuration
+	// and use default configuration instead
+	struct cPort newPort = {
+		.PortId  = port,
+		.QueuesNumber = rx_rings
+	};
+	// Stop all queues except the last one. Queues will be added later if needed
+	for (q = 0; q < rx_rings - 1; q++) {
+		changeRSSReta(&newPort, false);
+	}
 
 	return 0;
 }
@@ -212,7 +280,7 @@ struct rte_mbuf* reassemble(struct rte_ip_frag_tbl* tbl, struct rte_mbuf *buf, s
 	return buf;
 }
 
-void nff_go_recv(uint8_t port, int16_t queue, struct rte_ring *out_ring, int coreId) {
+void nff_go_recv(uint8_t port, int16_t queue, struct rte_ring *out_ring, volatile int *flag, int coreId) {
 	setAffinity(coreId);
 
 	struct rte_mbuf *bufs[BURST_SIZE];
@@ -226,7 +294,7 @@ void nff_go_recv(uint8_t port, int16_t queue, struct rte_ring *out_ring, int cor
 	struct rte_mbuf *temp;
 #endif
 	// Run until the application is quit. Recv can't be stopped now.
-	for (;;) {
+	while (*flag == 1) {
 		// Get RX packets from port
 		if (queue != -1) {
 			rx_pkts_number = rte_eth_rx_burst(port, queue, bufs, BURST_SIZE);

--- a/test/performance/latency/latency-part1.go
+++ b/test/performance/latency/latency-part1.go
@@ -120,11 +120,7 @@ func main() {
 	CheckFatal(flow.SetSender(outputFlow2, uint8(outport)))
 
 	// Create receiving flow and set a checking function for it
-	inputFlow1, err := flow.SetReceiver(uint8(inport))
-	CheckFatal(err)
-	inputFlow2, err := flow.SetReceiver(uint8(inport))
-	CheckFatal(err)
-	inputFlow, err := flow.SetMerger(inputFlow1, inputFlow2)
+	inputFlow, err := flow.SetReceiver(uint8(inport))
 	CheckFatal(err)
 
 	// Calculate latency only for 1 of skipNumber packets.

--- a/test/performance/perf_light.go
+++ b/test/performance/perf_light.go
@@ -14,10 +14,8 @@ import (
 )
 
 var (
-	mode uint
-
-	inport1     uint
-	inport2     uint
+	mode        uint
+	inport      uint
 	outport1    uint
 	outport2    uint
 	noscheduler bool
@@ -35,8 +33,7 @@ func main() {
 	flag.UintVar(&mode, "mode", 0, "Benching mode: 0 - empty, 1 - parsing, 2 - parsing, reading, writing")
 	flag.UintVar(&outport1, "outport1", 1, "port for 1st sender")
 	flag.UintVar(&outport2, "outport2", 1, "port for 2nd sender")
-	flag.UintVar(&inport1, "inport1", 0, "port for 1st receiver")
-	flag.UintVar(&inport2, "inport2", 0, "port for 2nd receiver")
+	flag.UintVar(&inport, "inport", 0, "port for receiver")
 	flag.BoolVar(&noscheduler, "no-scheduler", false, "disable scheduler")
 	dpdkLogLevel := *(flag.String("dpdk", "--log-level=0", "Passes an arbitrary argument to dpdk EAL"))
 	flag.Parse()
@@ -49,12 +46,7 @@ func main() {
 	CheckFatal(flow.SystemInit(&config))
 
 	// Receive packets from zero port. One queue per receive will be added automatically.
-	firstFlow0, err := flow.SetReceiver(uint8(inport1))
-	CheckFatal(err)
-	firstFlow1, err := flow.SetReceiver(uint8(inport2))
-	CheckFatal(err)
-
-	firstFlow, err := flow.SetMerger(firstFlow0, firstFlow1)
+	firstFlow, err := flow.SetReceiver(uint8(inport))
 	CheckFatal(err)
 
 	// Handle second flow via some heavy function

--- a/test/performance/perf_main.go
+++ b/test/performance/perf_main.go
@@ -14,11 +14,9 @@ import (
 )
 
 var (
-	load   uint
-	loadRW uint
-
-	inport1     uint
-	inport2     uint
+	load        uint
+	loadRW      uint
+	inport      uint
 	outport1    uint
 	outport2    uint
 	noscheduler bool
@@ -38,8 +36,7 @@ func main() {
 
 	flag.UintVar(&outport1, "outport1", 1, "port for 1st sender")
 	flag.UintVar(&outport2, "outport2", 1, "port for 2nd sender")
-	flag.UintVar(&inport1, "inport1", 0, "port for 1st receiver")
-	flag.UintVar(&inport2, "inport2", 0, "port for 2nd receiver")
+	flag.UintVar(&inport, "inport", 0, "port for receiver")
 	flag.BoolVar(&noscheduler, "no-scheduler", false, "disable scheduler")
 	dpdkLogLevel := *(flag.String("dpdk", "--log-level=0", "Passes an arbitrary argument to dpdk EAL"))
 	flag.Parse()
@@ -52,12 +49,7 @@ func main() {
 	CheckFatal(flow.SystemInit(&config))
 
 	// Receive packets from zero port. One queue per receive will be added automatically.
-	firstFlow0, err := flow.SetReceiver(uint8(inport1))
-	CheckFatal(err)
-	firstFlow1, err := flow.SetReceiver(uint8(inport2))
-	CheckFatal(err)
-
-	firstFlow, err := flow.SetMerger(firstFlow0, firstFlow1)
+	firstFlow, err := flow.SetReceiver(uint8(inport))
 	CheckFatal(err)
 
 	// Handle second flow via some heavy function

--- a/test/performance/perf_seq.go
+++ b/test/performance/perf_seq.go
@@ -14,11 +14,9 @@ import (
 )
 
 var (
-	load uint
-	mode uint
-
-	inport1     uint
-	inport2     uint
+	load        uint
+	mode        uint
+	inport      uint
 	outport1    uint
 	outport2    uint
 	noscheduler bool
@@ -38,8 +36,7 @@ func main() {
 	flag.UintVar(&mode, "mode", 2, "Benching mode: 2, 12 - two handles; 3, 13 - tree handles; 4, 14 - four handles. 2,3,4 - one flow; 12,13,14 - two flows")
 	flag.UintVar(&outport1, "outport1", 1, "port for 1st sender")
 	flag.UintVar(&outport2, "outport2", 1, "port for 2nd sender")
-	flag.UintVar(&inport1, "inport1", 0, "port for 1st receiver")
-	flag.UintVar(&inport2, "inport2", 0, "port for 2nd receiver")
+	flag.UintVar(&inport, "inport", 0, "port for receiver")
 	flag.BoolVar(&noscheduler, "no-scheduler", false, "disable scheduler")
 	dpdkLogLevel := *(flag.String("dpdk", "--log-level=0", "Passes an arbitrary argument to dpdk EAL"))
 	flag.Parse()
@@ -55,12 +52,7 @@ func main() {
 	var afterFlow *flow.Flow
 
 	// Receive packets from zero port. One queue will be added automatically.
-	firstFlow0, err := flow.SetReceiver(uint8(inport1))
-	CheckFatal(err)
-	firstFlow1, err := flow.SetReceiver(uint8(inport2))
-	CheckFatal(err)
-
-	firstFlow, err := flow.SetMerger(firstFlow0, firstFlow1)
+	firstFlow, err := flow.SetReceiver(uint8(inport))
 	CheckFatal(err)
 
 	if mode > 10 {


### PR DESCRIPTION
Scaling is implemented by changing RETA table, queues don't stop or start.
Performance results are more fluky but this is due
1) Following heuristics which are quite old and inefficient
2) Changing of static RSS to dynamic
However now user shouldn't write strange double receive constructs with merging -
Everything will be cloned automatically.
Two receive functions for one port is now prohibited.