### PR TITLE
Combined clonable flow functions to one "Segment" flow function

### DIFF
--- a/asm/asm.go
+++ b/asm/asm.go
@@ -12,3 +12,5 @@ func RteCompilerWmb()
 
 // Prefetcht0 is prefetch
 func Prefetcht0(addr uintptr)
+
+func GenerateMask(v1 *([32]uint8), v2 *([32]uint8), previousMask *([32]bool), result *([32]bool)) bool

--- a/asm/asm.s
+++ b/asm/asm.s
@@ -13,3 +13,18 @@ TEXT ·Prefetcht0(SB),NOSPLIT,$0-8
         MOVQ    addr+0(FP), AX
         PREFETCHT0      (AX)
         RET
+TEXT ·GenerateMask(SB),NOSPLIT,$0-33
+        MOVQ    v1+0(FP), AX
+        MOVQ    v2+8(FP), BX
+        MOVQ    previousMask+16(FP), CX
+        MOVQ    result+24(FP), DX
+        VMOVDQU (AX), Y0
+        VMOVDQU (BX), Y1
+        VMOVDQU (CX), Y2
+        VPCMPEQB Y0, Y1, Y0
+        VPAND Y0, Y2, Y0
+        VPTEST Y0, Y0
+        SETEQ a+32(FP)
+        VMOVDQU Y0, (DX)
+        VZEROUPPER
+        RET

--- a/examples/tutorial/step10.go
+++ b/examples/tutorial/step10.go
@@ -9,6 +9,8 @@ import "github.com/intel-go/nff-go/packet"
 
 var rulesp unsafe.Pointer
 
+const vecSize = 32
+
 func main() {
 	config := flow.Config{}
 	checkFatal(flow.SystemInit(&config))
@@ -38,15 +40,17 @@ func mySplitter(cur *packet.Packet, ctx flow.UserContext) uint {
 	return cur.L3ACLPort(localL3Rules)
 }
 
-func myHandler(curV []*packet.Packet, num uint, ctx flow.UserContext) {
-	for i := uint(0); i < num; i++ {
-		cur := curV[i]
-		cur.EncapsulateHead(common.EtherLen, common.IPv4MinLen)
-		cur.ParseL3()
-		cur.GetIPv4NoCheck().SrcAddr = packet.BytesToIPv4(111, 22, 3, 0)
-		cur.GetIPv4NoCheck().DstAddr = packet.BytesToIPv4(3, 22, 111, 0)
-		cur.GetIPv4NoCheck().VersionIhl = 0x45
-		cur.GetIPv4NoCheck().NextProtoID = 0x04
+func myHandler(curV []*packet.Packet, mask *[vecSize]bool, ctx flow.UserContext) {
+	for i := uint(0); i < 32; i++ {
+		if (*mask)[i] == true {
+			cur := curV[i]
+			cur.EncapsulateHead(common.EtherLen, common.IPv4MinLen)
+			cur.ParseL3()
+			cur.GetIPv4NoCheck().SrcAddr = packet.BytesToIPv4(111, 22, 3, 0)
+			cur.GetIPv4NoCheck().DstAddr = packet.BytesToIPv4(3, 22, 111, 0)
+			cur.GetIPv4NoCheck().VersionIhl = 0x45
+			cur.GetIPv4NoCheck().NextProtoID = 0x04
+		}
 	}
 }
 

--- a/flow/flow.go
+++ b/flow/flow.go
@@ -46,11 +46,51 @@ var openFlowsNumber = uint32(0)
 var ringName = 1
 var createdPorts []port
 var schedState *scheduler
+var vEach [10][burstSize]uint8
+
+type processSegment struct {
+	out      []*low.Ring
+	contexts []UserContext
+	stype    uint8
+}
 
 // Flow is an abstraction for connecting flow functions with each other.
 // Flow shouldn't be understood in any way beyond this.
 type Flow struct {
-	current *low.Ring
+	current  *low.Ring
+	segment  *processSegment
+	previous **Func
+}
+
+type partitionCtx struct {
+	currentAnswer       uint8
+	currentCompare      uint64
+	currentPacketNumber uint64
+	N                   uint64
+	M                   uint64
+}
+
+func (c partitionCtx) Copy() interface{} {
+	return &partitionCtx{N: c.N, M: c.M, currentCompare: c.N}
+}
+
+func (c partitionCtx) Delete() {
+}
+
+type Func struct {
+	sHandleFunction   HandleFunction
+	sSeparateFunction SeparateFunction
+	sSplitFunction    SplitFunction
+	sFunc             func(*packet.Packet, *Func, UserContext) uint
+	vHandleFunction   VectorHandleFunction
+	vSeparateFunction VectorSeparateFunction
+	vSplitFunction    VectorSplitFunction
+	vFunc             func([]*packet.Packet, *[burstSize]bool, *[burstSize]uint8, *Func, UserContext)
+
+	next            [](*Func)
+	bufIndex        uint
+	contextIndex    int
+	followingNumber uint8
 }
 
 // GenerateFunction is a function type for user defined function which generates packets.
@@ -68,7 +108,7 @@ type VectorGenerateFunction func([]*packet.Packet, uint, UserContext)
 type HandleFunction func(*packet.Packet, UserContext)
 
 // VectorHandleFunction is a function type like GenerateFunction for vector handling
-type VectorHandleFunction func([]*packet.Packet, uint, UserContext)
+type VectorHandleFunction func([]*packet.Packet, *[burstSize]bool, UserContext)
 
 // SeparateFunction is a function type for user defined function which separates packets
 // based on some rule for two flows. Functions receives a packet from flow.
@@ -77,7 +117,7 @@ type VectorHandleFunction func([]*packet.Packet, uint, UserContext)
 type SeparateFunction func(*packet.Packet, UserContext) bool
 
 // VectorSeparateFunction is a function type like GenerateFunction for vector separation
-type VectorSeparateFunction func([]*packet.Packet, []bool, uint, UserContext)
+type VectorSeparateFunction func([]*packet.Packet, *[burstSize]bool, *[burstSize]uint8, UserContext)
 
 // SplitFunction is a function type for user defined function which splits packets
 // based in some rule for multiple flows. Function receives a packet from
@@ -87,6 +127,8 @@ type VectorSeparateFunction func([]*packet.Packet, []bool, uint, UserContext)
 // output flow is used for dropping packets - "Stop" function should be
 // set after "Split" function in it.
 type SplitFunction func(*packet.Packet, UserContext) uint
+
+type VectorSplitFunction func([]*packet.Packet, *[burstSize]bool, *[burstSize]uint8, UserContext)
 
 // Kni is a high level struct of KNI device. The device itself is stored
 // in C memory in low.c and is defined by its port which is equal to port
@@ -136,7 +178,9 @@ func addFastGenerator(out *low.Ring, generateFunction GenerateFunction,
 	par.mempool = low.CreateMempool()
 	par.vectorGenerateFunction = vectorGenerateFunction
 	par.targetSpeed = float64(targetSpeed)
-	schedState.addFF("fast generator", nil, nil, generatePerf, par, make(chan uint64, 50), context, fastGenerate)
+	ctx := make([]UserContext, 1, 1)
+	ctx[0] = context
+	schedState.addFF("fast generator", nil, nil, generatePerf, par, make(chan uint64, 50), &ctx, fastGenerate)
 }
 
 type sendParameters struct {
@@ -166,80 +210,49 @@ func addCopier(in *low.Ring, out *low.Ring, outCopy *low.Ring) {
 	par.out = out
 	par.outCopy = outCopy
 	par.mempool = low.CreateMempool()
-	schedState.addFF("copy", nil, nil, pcopy, par, make(chan uint64, 50), nil, handleSplitSeparateCopy)
+	schedState.addFF("copy", nil, nil, pcopy, par, make(chan uint64, 50), nil, segmentCopy)
 }
 
-type partitionParameters struct {
-	in        *low.Ring
-	outFirst  *low.Ring
-	outSecond *low.Ring
-	N         uint64
-	M         uint64
+func makePartitioner(N uint64, M uint64) *Func {
+	f := new(Func)
+	f.sFunc = partition
+	f.vFunc = vPartition
+	f.next = make([]*Func, 2, 2)
+	f.followingNumber = 2
+	return f
 }
 
-func addPartitioner(in *low.Ring, outFirst *low.Ring, outSecond *low.Ring, N uint64, M uint64) {
-	par := new(partitionParameters)
-	par.in = in
-	par.outFirst = outFirst
-	par.outSecond = outSecond
-	par.N = N
-	par.M = M
-	schedState.addFF("partitioner", partition, nil, nil, par, nil, nil, other)
+func makeSeparator(separateFunction SeparateFunction, vectorSeparateFunction VectorSeparateFunction) *Func {
+	f := new(Func)
+	f.sSeparateFunction = separateFunction
+	f.vSeparateFunction = vectorSeparateFunction
+	f.sFunc = separate
+	f.vFunc = vSeparate
+	f.next = make([]*Func, 2, 2)
+	f.followingNumber = 2
+	return f
 }
 
-type separateParameters struct {
-	in                     *low.Ring
-	outTrue                *low.Ring
-	outFalse               *low.Ring
-	separateFunction       SeparateFunction
-	vectorSeparateFunction VectorSeparateFunction
+func makeSplitter(splitFunction SplitFunction, vectorSplitFunction VectorSplitFunction, n uint8) *Func {
+	f := new(Func)
+	f.sSplitFunction = splitFunction
+	f.vSplitFunction = vectorSplitFunction
+	f.sFunc = split
+	f.vFunc = vSplit
+	f.next = make([]*Func, n, n)
+	f.followingNumber = n
+	return f
 }
 
-func addSeparator(in *low.Ring, outTrue *low.Ring, outFalse *low.Ring,
-	separateFunction SeparateFunction, vectorSeparateFunction VectorSeparateFunction,
-	name string, context UserContext) {
-	par := new(separateParameters)
-	par.in = in
-	par.outTrue = outTrue
-	par.outFalse = outFalse
-	par.separateFunction = separateFunction
-	par.vectorSeparateFunction = vectorSeparateFunction
-	schedState.addFF(name, nil, nil, separate, par, make(chan uint64, 50), context, handleSplitSeparateCopy)
-}
-
-type splitParameters struct {
-	in            *low.Ring
-	outs          []*low.Ring
-	splitFunction SplitFunction
-	flowNumber    uint
-}
-
-func addSplitter(in *low.Ring, outs []*low.Ring,
-	splitFunction SplitFunction, flowNumber uint, context UserContext) {
-	par := new(splitParameters)
-	par.in = in
-	par.outs = outs
-	par.splitFunction = splitFunction
-	par.flowNumber = flowNumber
-	schedState.addFF("splitter", nil, nil, split, par, make(chan uint64, 50), context, handleSplitSeparateCopy)
-}
-
-type handleParameters struct {
-	in                   *low.Ring
-	out                  *low.Ring
-	handleFunction       HandleFunction
-	vectorHandleFunction VectorHandleFunction
-}
-
-func addHandler(in *low.Ring, out *low.Ring,
-	handleFunction HandleFunction, vectorHandleFunction VectorHandleFunction,
-	name string, context UserContext) {
-	par := new(handleParameters)
-	par.in = in
-	par.out = out
-	par.handleFunction = handleFunction
-	par.vectorHandleFunction = vectorHandleFunction
-	schedState.addFF(name, nil, nil, handle, par, make(chan uint64, 50), context, handleSplitSeparateCopy)
+func makeHandler(handleFunction HandleFunction, vectorHandleFunction VectorHandleFunction) *Func {
+	f := new(Func)
+	f.sHandleFunction = handleFunction
+	f.vHandleFunction = vectorHandleFunction
+	f.sFunc = handle
+	f.vFunc = vHandle
+	f.next = make([]*Func, 1, 1)
+	f.followingNumber = 1
+	return f
 }
 
 type writeParameters struct {
@@ -268,7 +281,38 @@ func addReader(filename string, out *low.Ring, repcount int32) {
 	schedState.addFF("reader", read, nil, nil, par, nil, nil, other)
 }
 
-var burstSize uint
+func makeSlice(out *low.Ring, segment *processSegment) *Func {
+	f := new(Func)
+	f.sFunc = constructSlice
+	f.vFunc = vConstructSlice
+	segment.out = append(segment.out, out)
+	f.bufIndex = uint(len(segment.out) - 1)
+	f.followingNumber = 0
+	return f
+}
+
+type segmentParameters struct {
+	in        *low.Ring
+	out       *([](*low.Ring))
+	firstFunc *Func
+	stype     *uint8
+}
+
+func addSegment(in *low.Ring, first *Func) *processSegment {
+	par := new(segmentParameters)
+	par.in = in
+	par.firstFunc = first
+	segment := new(processSegment)
+	segment.out = make([](*low.Ring), 0, 0)
+	segment.contexts = make([](UserContext), 0, 0)
+	par.out = &segment.out
+	par.stype = &segment.stype
+	schedState.addFF("segment", nil, nil, segmentProcess, par, make(chan uint64, 50), &segment.contexts, segmentCopy)
+	return segment
+}
+
+const burstSize = 32
+
 var sizeMultiplier uint
 var schedTime uint
 var hwtxchecksum bool
@@ -306,16 +350,12 @@ type Config struct {
 	// Specifies number of mbufs in per-CPU core cache in
 	// mempool. Default value is 250.
 	MbufCacheSize uint
-	// Number of BurstSize groups in all rings. This should be power
+	// Number of burstSize groups in all rings. This should be power
 	// of 2. Default value is 256.
 	RingSize uint
 	// Time between scheduler actions in miliseconds. Default value is
 	// 1500.
 	ScaleTime uint
-	// Number of mbufs per one enqueue / dequeue from ring. Default
-	// value is tested for performance and not recommended to
-	// change. Default value is 32.
-	BurstSize uint
 	// Time in miliseconds for scheduler to check changing of flow
 	// function behaviour. Default value is 10000.
 	CheckTime uint
@@ -332,7 +372,6 @@ type Config struct {
 }
 
 // SystemInit is initialization of system. This function should be always called before graph construction.
-// Function can panic during execution.
 func SystemInit(args *Config) error {
 	CPUCoresNumber := runtime.NumCPU()
 	var cpus []int
@@ -368,11 +407,6 @@ func SystemInit(args *Config) error {
 	schedTime = 500
 	if args.ScaleTime != 0 {
 		schedTime = args.ScaleTime
-	}
-
-	burstSize = 32
-	if args.BurstSize != 0 {
-		burstSize = args.BurstSize
 	}
 
 	checkTime := uint(10000)
@@ -423,6 +457,11 @@ func SystemInit(args *Config) error {
 	packet.SetHWTXChecksumFlag(hwtxchecksum)
 	// Init low performance mempool
 	packet.SetNonPerfMempool(low.CreateMempool())
+	for i := 0; i < 10; i++ {
+		for j := 0; j < burstSize; j++ {
+			vEach[i][j] = uint8(i)
+		}
+	}
 	return nil
 }
 
@@ -467,14 +506,11 @@ func generateRingName() string {
 // SetSenderFile adds write function to flow graph.
 // Gets flow which packets will be written to file and
 // target file name.
-// Function can panic during execution.
 func SetSenderFile(IN *Flow, filename string) error {
 	if err := checkFlow(IN); err != nil {
 		return err
 	}
-	addWriter(filename, IN.current)
-	IN.current = nil
-	openFlowsNumber--
+	addWriter(filename, finishFlow(IN))
 	return nil
 }
 
@@ -482,21 +518,16 @@ func SetSenderFile(IN *Flow, filename string) error {
 // Gets name of pcap formatted file and number of reads. If repcount = -1,
 // file is read infinitely in circle.
 // Returns new opened flow with read packets.
-// Function can panic during execution.
 func SetReceiverFile(filename string, repcount int32) (OUT *Flow) {
 	ring := low.CreateRing(generateRingName(), burstSize*sizeMultiplier)
 	addReader(filename, ring, repcount)
-	OUT = new(Flow)
-	OUT.current = ring
-	openFlowsNumber++
-	return OUT
+	return newFlow(ring)
 }
 
 // SetReceiver adds receive function to flow graph.
 // Gets port number from which packets will be received.
 // Receive queue will be added to port automatically.
 // Returns new opened flow with received packets
-// Function can panic during execution.
 func SetReceiver(portId uint8) (OUT *Flow, err error) {
 	if portId >= uint8(len(createdPorts)) {
 		return nil, common.WrapWithNFError(nil, "Requested receive port exceeds number of ports which can be used by DPDK (bind to DPDK).", common.ReqTooManyPorts)
@@ -508,31 +539,23 @@ func SetReceiver(portId uint8) (OUT *Flow, err error) {
 	createdPorts[portId].willReceive = true
 	ring := low.CreateRing(generateRingName(), burstSize*sizeMultiplier)
 	addReceiver(portId, false, ring)
-	OUT = new(Flow)
-	OUT.current = ring
-	openFlowsNumber++
-	return OUT, nil
+	return newFlow(ring), nil
 }
 
 // SetReceiverKNI adds function receive from KNI to flow graph.
 // Gets KNI device from which packets will be received.
 // Receive queue will be added to port automatically.
 // Returns new opened flow with received packets
-// Function can panic during execution.
 func SetReceiverKNI(kni *Kni) (OUT *Flow) {
 	ring := low.CreateRing(generateRingName(), burstSize*sizeMultiplier)
 	addReceiver(kni.portId, true, ring)
-	OUT = new(Flow)
-	OUT.current = ring
-	openFlowsNumber++
-	return OUT
+	return newFlow(ring)
 }
 
 // SetFastGenerator adds clonable generate function to flow graph.
 // Gets user-defined generate function, target speed of generation user wants to achieve and context.
 // Returns new open flow with generated packets.
 // Function tries to achieve target speed by cloning.
-// Function can panic during execution.
 func SetFastGenerator(f func(*packet.Packet, UserContext), targetSpeed uint64, context UserContext) (OUT *Flow, err error) {
 	ring := low.CreateRing(generateRingName(), burstSize*sizeMultiplier)
 	if targetSpeed > 0 {
@@ -540,17 +563,13 @@ func SetFastGenerator(f func(*packet.Packet, UserContext), targetSpeed uint64, c
 	} else {
 		return nil, common.WrapWithNFError(nil, "Target speed value should be > 0", common.BadArgument)
 	}
-	OUT = new(Flow)
-	OUT.current = ring
-	openFlowsNumber++
-	return OUT, nil
+	return newFlow(ring), nil
 }
 
 // SetVectorFastGenerator adds clonable vector generate function to flow graph.
 // Gets user-defined vector generate function, target speed of generation user wants to achieve and context.
 // Returns new open flow with generated packets.
 // Function tries to achieve target speed by cloning.
-// Function can panic during execution.
 func SetVectorFastGenerator(f func([]*packet.Packet, uint, UserContext), targetSpeed uint64, context UserContext) (OUT *Flow, err error) {
 	ring := low.CreateRing(generateRingName(), burstSize*sizeMultiplier)
 	if targetSpeed > 0 {
@@ -558,10 +577,7 @@ func SetVectorFastGenerator(f func([]*packet.Packet, uint, UserContext), targetS
 	} else {
 		return nil, common.WrapWithNFError(nil, "Target speed value should be > 0", common.BadArgument)
 	}
-	OUT = new(Flow)
-	OUT.current = ring
-	openFlowsNumber++
-	return OUT, nil
+	return newFlow(ring), nil
 }
 
 // SetGenerator adds non-clonable generate flow function to flow graph.
@@ -569,20 +585,15 @@ func SetVectorFastGenerator(f func([]*packet.Packet, uint, UserContext), targetS
 // Returns new open flow with generated packets.
 // Single packet non-clonable flow function will be added. It can be used for waiting of
 // input user packets.
-// Function can panic during execution.
 func SetGenerator(f func(*packet.Packet, UserContext), context UserContext) (OUT *Flow) {
 	ring := low.CreateRing(generateRingName(), burstSize*sizeMultiplier)
 	addGenerator(ring, GenerateFunction(f))
-	OUT = new(Flow)
-	OUT.current = ring
-	openFlowsNumber++
-	return OUT
+	return newFlow(ring)
 }
 
 // SetSender adds send function to flow graph.
 // Gets flow which will be closed and its packets will be send and port number for which packets will be sent.
 // Send queue will be added to port automatically.
-// Function can panic during execution.
 func SetSender(IN *Flow, portId uint8) error {
 	if err := checkFlow(IN); err != nil {
 		return err
@@ -591,105 +602,78 @@ func SetSender(IN *Flow, portId uint8) error {
 		return common.WrapWithNFError(nil, "Requested send port exceeds number of ports which can be used by DPDK (bind to DPDK).", common.ReqTooManyPorts)
 	}
 	createdPorts[portId].wasRequested = true
-	addSender(portId, createdPorts[portId].txQueuesNumber, IN.current)
+	addSender(portId, createdPorts[portId].txQueuesNumber, finishFlow(IN))
 	createdPorts[portId].txQueuesNumber++
-	IN.current = nil
-	openFlowsNumber--
 	return nil
 }
 
 // SetSenderKNI adds function sending to KNI to flow graph.
 // Gets flow which will be closed and its packets will be send to given KNI device.
 // Send queue will be added to port automatically.
-// Function can panic during execution.
 func SetSenderKNI(IN *Flow, kni *Kni) error {
 	if err := checkFlow(IN); err != nil {
 		return err
 	}
-	addSender(kni.portId, -1, IN.current)
-	IN.current = nil
-	openFlowsNumber--
+	addSender(kni.portId, -1, finishFlow(IN))
 	return nil
 }
 
 // SetCopier adds copy function to flow graph.
 // Gets flow which will be copied.
-// Function can panic during execution.
 func SetCopier(IN *Flow) (OUT *Flow, err error) {
 	if err := checkFlow(IN); err != nil {
 		return nil, err
 	}
-	OUT = new(Flow)
 	ringFirst := low.CreateRing(generateRingName(), burstSize*sizeMultiplier)
 	ringSecond := low.CreateRing(generateRingName(), burstSize*sizeMultiplier)
-	openFlowsNumber++
 	addCopier(IN.current, ringFirst, ringSecond)
 	IN.current = ringFirst
-	OUT.current = ringSecond
-	return OUT, nil
+	return newFlow(ringSecond), nil
 }
 
 // SetPartitioner adds partition function to flow graph.
 // Gets input flow and N and M constants. Returns new opened flow.
 // Each loop N packets will be remained in input flow, next M packets will be sent to new flow.
 // It is advised not to use this function less then (75, 75) for performance reasons.
-// Function can panic during execution.
 // We make partition function unclonable. The most complex task is (1,1).
 // It means that if you would like to simply divide a flow
 // it is recommended to use (75,75) instead of (1,1) for performance reasons.
 func SetPartitioner(IN *Flow, N uint64, M uint64) (OUT *Flow, err error) {
-	if err := checkFlow(IN); err != nil {
-		return nil, err
-	}
-	OUT = new(Flow)
 	if N == 0 || M == 0 {
 		common.LogWarning(common.Initialization, "One of SetPartitioner function's arguments is zero.")
 	}
-	ringFirst := low.CreateRing(generateRingName(), burstSize*sizeMultiplier)
-	ringSecond := low.CreateRing(generateRingName(), burstSize*sizeMultiplier)
-	openFlowsNumber++
-	addPartitioner(IN.current, ringFirst, ringSecond, N, M)
-	IN.current = ringFirst
-	OUT.current = ringSecond
-	return OUT, nil
+	partition := makePartitioner(N, M)
+	ctx := new(partitionCtx)
+	ctx.N = N
+	ctx.M = M
+	if err := segmentInsert(IN, partition, false, *ctx, 0); err != nil {
+		return nil, err
+	}
+	return newFlowSegment(IN.segment, &partition.next[1]), nil
 }
 
 // SetSeparator adds separate function to flow graph.
 // Gets flow, user defined separate function and context. Returns new opened flow.
 // Each packet from input flow will be remain inside input packet if
 // user defined function returns "true" and is sent to new flow otherwise.
-// Function can panic during execution.
-func SetSeparator(IN *Flow, f func(*packet.Packet, UserContext) bool, context UserContext) (OUT *Flow, err error) {
-	if err := checkFlow(IN); err != nil {
+func SetSeparator(IN *Flow, separateFunction SeparateFunction, context UserContext) (OUT *Flow, err error) {
+	separate := makeSeparator(separateFunction, nil)
+	if err := segmentInsert(IN, separate, false, context, 1); err != nil {
 		return nil, err
 	}
-	OUT = new(Flow)
-	ringTrue := low.CreateRing(generateRingName(), burstSize*sizeMultiplier)
-	ringFalse := low.CreateRing(generateRingName(), burstSize*sizeMultiplier)
-	openFlowsNumber++
-	addSeparator(IN.current, ringTrue, ringFalse, SeparateFunction(f), nil, "separator", context)
-	IN.current = ringTrue
-	OUT.current = ringFalse
-	return OUT, nil
+	return newFlowSegment(IN.segment, &separate.next[1]), nil
 }
 
 // SetVectorSeparator adds vector separate function to flow graph.
 // Gets flow, user defined vector separate function and context. Returns new opened flow.
 // Each packet from input flow will be remain inside input packet if
 // user defined function returns "true" and is sent to new flow otherwise.
-// Function can panic during execution.
-func SetVectorSeparator(IN *Flow, f func([]*packet.Packet, []bool, uint, UserContext), context UserContext) (OUT *Flow, err error) {
-	if err := checkFlow(IN); err != nil {
+func SetVectorSeparator(IN *Flow, vectorSeparateFunction VectorSeparateFunction, context UserContext) (OUT *Flow, err error) {
+	separate := makeSeparator(nil, vectorSeparateFunction)
+	if err := segmentInsert(IN, separate, false, context, 2); err != nil {
 		return nil, err
 	}
-	OUT = new(Flow)
-	ringTrue := low.CreateRing(generateRingName(), burstSize*sizeMultiplier)
-	ringFalse := low.CreateRing(generateRingName(), burstSize*sizeMultiplier)
-	openFlowsNumber++
-	addSeparator(IN.current, ringTrue, ringFalse, nil, VectorSeparateFunction(f), "vector separator", context)
-	IN.current = ringTrue
-	OUT.current = ringFalse
-	return OUT, nil
+	return newFlowSegment(IN.segment, &separate.next[1]), nil
 }
 
 // SetSplitter adds split function to flow graph.
@@ -697,35 +681,32 @@ func SetVectorSeparator(IN *Flow, f func([]*packet.Packet, []bool, uint, UserCon
 // Returns array of new opened flows with corresponding length.
 // Each packet from input flow will be sent to one of new flows based on
 // user defined function output for this packet.
-// Function can panic during execution.
 func SetSplitter(IN *Flow, splitFunction SplitFunction, flowNumber uint, context UserContext) (OutArray [](*Flow), err error) {
 	if err := checkFlow(IN); err != nil {
 		return nil, err
 	}
+	split := makeSplitter(splitFunction, nil, uint8(flowNumber))
+	segmentInsert(IN, split, true, context, 1)
 	OutArray = make([](*Flow), flowNumber, flowNumber)
-	rings := make([](*low.Ring), flowNumber, flowNumber)
 	for i := range OutArray {
-		OutArray[i] = new(Flow)
-		openFlowsNumber++
-		rings[i] = low.CreateRing(generateRingName(), burstSize*sizeMultiplier)
-		OutArray[i].current = rings[i]
+		OutArray[i] = newFlowSegment(IN.segment, &split.next[i])
 	}
-	addSplitter(IN.current, rings, splitFunction, flowNumber, context)
-	IN.current = nil
-	openFlowsNumber--
 	return OutArray, nil
 }
 
 // SetStopper adds stop function to flow graph.
 // Gets flow which will be closed and all packets from each will be dropped.
-// Function can panic during execution.
 func SetStopper(IN *Flow) error {
 	if err := checkFlow(IN); err != nil {
 		return err
 	}
-	merge(IN.current, schedState.StopRing)
-	IN.current = nil
-	openFlowsNumber--
+	if IN.segment == nil {
+		merge(IN.current, schedState.StopRing)
+		closeFlow(IN)
+	} else {
+		ms := makeSlice(schedState.StopRing, IN.segment)
+		segmentInsert(IN, ms, true, nil, 0)
+	}
 	return nil
 }
 
@@ -733,60 +714,42 @@ func SetStopper(IN *Flow) error {
 // Gets flow, user defined handle function and context.
 // Each packet from input flow will be handle inside user defined function
 // and sent further in the same flow.
-// Function can panic during execution.
-func SetHandler(IN *Flow, f func(*packet.Packet, UserContext), context UserContext) error {
-	if err := checkFlow(IN); err != nil {
-		return err
-	}
-	ring := low.CreateRing(generateRingName(), burstSize*sizeMultiplier)
-	addHandler(IN.current, ring, HandleFunction(f), nil, "handler", context)
-	IN.current = ring
-	return nil
+func SetHandler(IN *Flow, handleFunction HandleFunction, context UserContext) error {
+	handle := makeHandler(handleFunction, nil)
+	return segmentInsert(IN, handle, false, context, 1)
 }
 
 // SetVectorHandler adds vector handle function to flow graph.
 // Gets flow, user defined vector handle function and context.
 // Each packet from input flow will be handle inside user defined function
 // and sent further in the same flow.
-// Function can panic during execution.
-func SetVectorHandler(IN *Flow, f func([]*packet.Packet, uint, UserContext), context UserContext) error {
-	if err := checkFlow(IN); err != nil {
-		return err
-	}
-	ring := low.CreateRing(generateRingName(), burstSize*sizeMultiplier)
-	addHandler(IN.current, ring, nil, VectorHandleFunction(f), "vector handler", context)
-	IN.current = ring
-	return nil
+func SetVectorHandler(IN *Flow, vectorHandleFunction VectorHandleFunction, context UserContext) error {
+	handle := makeHandler(nil, vectorHandleFunction)
+	return segmentInsert(IN, handle, false, context, 2)
 }
 
 // SetHandlerDrop adds vector handle function to flow graph.
 // Gets flow, user defined handle function and context.
 // User defined function can return boolean value.
 // If user function returns false after handling a packet it is dropped automatically.
-// Function can panic during execution.
-func SetHandlerDrop(IN *Flow, f func(*packet.Packet, UserContext) bool, context UserContext) error {
-	if err := checkFlow(IN); err != nil {
+func SetHandlerDrop(IN *Flow, separateFunction SeparateFunction, context UserContext) error {
+	separate := makeSeparator(separateFunction, nil)
+	if err := segmentInsert(IN, separate, false, context, 1); err != nil {
 		return err
 	}
-	ring := low.CreateRing(generateRingName(), burstSize*sizeMultiplier)
-	addSeparator(IN.current, ring, schedState.StopRing, SeparateFunction(f), nil, "handler", context)
-	IN.current = ring
-	return nil
+	return SetStopper(newFlowSegment(IN.segment, &separate.next[1]))
 }
 
 // SetVectorHandlerDrop adds vector handle function to flow graph.
 // Gets flow, user defined vector handle function and context.
 // User defined function can return boolean value.
 // If user function returns false after handling a packet it is dropped automatically.
-// Function can panic during execution.
-func SetVectorHandlerDrop(IN *Flow, f func([]*packet.Packet, []bool, uint, UserContext), context UserContext) error {
-	if err := checkFlow(IN); err != nil {
+func SetVectorHandlerDrop(IN *Flow, vectorSeparateFunction VectorSeparateFunction, context UserContext) error {
+	separate := makeSeparator(nil, vectorSeparateFunction)
+	if err := segmentInsert(IN, separate, false, context, 2); err != nil {
 		return err
 	}
-	ring := low.CreateRing(generateRingName(), burstSize*sizeMultiplier)
-	addSeparator(IN.current, ring, schedState.StopRing, nil, VectorSeparateFunction(f), "vector handler", context)
-	IN.current = ring
-	return nil
+	return SetStopper(newFlowSegment(IN.segment, &separate.next[1]))
 }
 
 // SetMerger adds merge function to flow graph.
@@ -799,19 +762,205 @@ func SetMerger(InArray ...*Flow) (OUT *Flow, err error) {
 		if err := checkFlow(InArray[i]); err != nil {
 			return nil, err
 		}
-		merge(InArray[i].current, ring)
-		InArray[i].current = nil
-		openFlowsNumber--
+		if InArray[i].segment == nil {
+			merge(InArray[i].current, ring)
+			closeFlow(InArray[i])
+		} else {
+			// TODO merge finishes segment even if this is merge inside it. Need to optimize.
+			ms := makeSlice(ring, InArray[i].segment)
+			segmentInsert(InArray[i], ms, true, nil, 0)
+		}
 	}
-	OUT = new(Flow)
-	OUT.current = ring
-	openFlowsNumber++
-	return OUT, nil
+	return newFlow(ring), nil
 }
 
 // GetPortMACAddress returns default MAC address of an Ethernet port.
 func GetPortMACAddress(port uint8) [common.EtherAddrLen]uint8 {
 	return low.GetPortMACAddress(port)
+}
+
+// Service functions for Flow
+func newFlow(ring *low.Ring) *Flow {
+	OUT := new(Flow)
+	OUT.current = ring
+	openFlowsNumber++
+	return OUT
+}
+
+func newFlowSegment(segment *processSegment, previous **Func) *Flow {
+	OUT := newFlow(nil)
+	OUT.segment = segment
+	OUT.previous = previous
+	return OUT
+}
+
+func finishFlow(IN *Flow) *low.Ring {
+	var ring *low.Ring
+	if IN.segment == nil {
+		ring = IN.current
+		closeFlow(IN)
+	} else {
+		ring = low.CreateRing(generateRingName(), burstSize*sizeMultiplier)
+		ms := makeSlice(ring, IN.segment)
+		segmentInsert(IN, ms, true, nil, 0)
+	}
+	return ring
+}
+
+func closeFlow(IN *Flow) {
+	IN.current = nil
+	IN.previous = nil
+	openFlowsNumber--
+}
+
+func segmentInsert(IN *Flow, f *Func, willClose bool, context UserContext, setType uint8) error {
+	if err := checkFlow(IN); err != nil {
+		return err
+	}
+	if IN.segment == nil {
+		IN.segment = addSegment(IN.current, f)
+		IN.segment.stype = setType
+	} else {
+		if setType > 0 && IN.segment.stype > 0 && setType != IN.segment.stype {
+			ring := low.CreateRing(generateRingName(), burstSize*sizeMultiplier)
+			ms := makeSlice(ring, IN.segment)
+			segmentInsert(IN, ms, false, nil, 0)
+			IN.segment = nil
+			IN.current = ring
+			segmentInsert(IN, f, willClose, context, setType)
+			return nil
+		}
+		if setType > 0 && IN.segment.stype == 0 {
+			IN.segment.stype = setType
+		}
+		*IN.previous = f
+	}
+	if willClose {
+		closeFlow(IN)
+	} else if f.next != nil {
+		IN.previous = &f.next[0]
+	}
+	IN.segment.contexts = append(IN.segment.contexts, context)
+	f.contextIndex = len(IN.segment.contexts) - 1
+	return nil
+}
+
+func segmentProcess(parameters interface{}, stopper chan int, report chan uint64, context []UserContext) {
+	// For scalar and vector parts
+	lp := parameters.(*segmentParameters)
+	IN := lp.in
+	OUT := *lp.out
+	scalar := (*lp.stype != 2)
+	outNumber := len(*lp.out)
+	InputMbufs := make([]uintptr, burstSize, burstSize)
+	OutputMbufs := make([][]uintptr, outNumber)
+	countOfPackets := make([]int, outNumber)
+	for index := range OutputMbufs {
+		OutputMbufs[index] = make([]uintptr, burstSize)
+		countOfPackets[index] = 0
+	}
+	var currentSpeed uint64
+	tick := time.Tick(time.Duration(schedTime) * time.Millisecond)
+	var pause int
+	firstFunc := lp.firstFunc
+	// For scalar part
+	var tempPacket *packet.Packet
+	var tempPacketAddr uintptr
+	// For vector part
+	tempPackets := make([]*packet.Packet, burstSize)
+	type pair struct {
+		f    *Func
+		mask [burstSize]bool
+	}
+	def := make([]pair, 30, 30)
+	var answers [burstSize]uint8
+
+	for {
+		select {
+		case pause = <-stopper:
+			if pause == -1 {
+				// It is time to close this clone
+				close(stopper)
+				for i := range context {
+					if context[i] != nil {
+						context[i].Delete()
+					}
+				}
+				// We don't close report channel because all clones of one function use it.
+				// As one function entity will be working endlessly we don't close it anywhere.
+				return
+			}
+		case <-tick:
+			report <- currentSpeed
+			currentSpeed = 0
+		default:
+			n := IN.DequeueBurst(InputMbufs, burstSize)
+			if n == 0 {
+				if pause != 0 {
+					time.Sleep(time.Duration(pause) * time.Nanosecond)
+				}
+				continue
+			}
+			// TODO prefetch
+			if scalar { // Scalar code
+				for i := uint(0); i < n; i++ {
+					currentFunc := firstFunc
+					tempPacketAddr = packet.ExtractPacketAddr(InputMbufs[i])
+					tempPacket = packet.ToPacket(tempPacketAddr)
+					for {
+						nextIndex := currentFunc.sFunc(tempPacket, currentFunc, context[currentFunc.contextIndex])
+						if currentFunc.followingNumber == 0 {
+							// We have constructSlice -> put packets to output slices
+							OutputMbufs[nextIndex][countOfPackets[nextIndex]] = InputMbufs[i]
+							countOfPackets[nextIndex]++
+							break
+						}
+						currentFunc = currentFunc.next[nextIndex]
+					}
+				}
+				for index := 0; index < outNumber; index++ {
+					if countOfPackets[index] == 0 {
+						continue
+					}
+					safeEnqueue(OUT[index], OutputMbufs[index], uint(countOfPackets[index]))
+					currentSpeed += uint64(countOfPackets[index])
+					countOfPackets[index] = 0
+				}
+			} else { // Vector code
+				packet.ExtractPackets(tempPackets, InputMbufs, n)
+				def[0].f = firstFunc
+				for i := uint(0); i < burstSize; i++ {
+					def[0].mask[i] = (i < n)
+				}
+				st := 0
+				for st != -1 {
+					cur := def[st].f
+					cur.vFunc(tempPackets, &def[st].mask, &answers, cur, context[cur.contextIndex])
+					if cur.followingNumber == 0 {
+						// We have constructSlice -> put packets inside ring, it is an end of segment
+						count := FillSliceFromMask(InputMbufs, &def[st].mask, OutputMbufs[0])
+						safeEnqueue(OUT[answers[0]], OutputMbufs[0], uint(count))
+						currentSpeed += uint64(count)
+					} else if cur.followingNumber == 1 {
+						// We have simple handle. Mask will remain the same, currect function will be changed
+						def[st].f = cur.next[0]
+						st++
+					} else {
+						step := 0
+						for i := int(cur.followingNumber - 1); i >= 0; i-- {
+							cont := asm.GenerateMask(&answers, &(vEach[i]), &def[st].mask, &def[st+i].mask)
+							if !cont {
+								def[st+i].f = cur.next[i]
+								step++
+							}
+						}
+						st += step
+					}
+					st--
+				}
+			}
+		}
+	}
 }
 
 func recvRSS(parameters interface{}, flag *int, coreID int) {
@@ -838,7 +987,7 @@ func generateOne(parameters interface{}) {
 	}
 }
 
-func generatePerf(parameters interface{}, stopper chan int, report chan uint64, context UserContext) {
+func generatePerf(parameters interface{}, stopper chan int, report chan uint64, context []UserContext) {
 	gp := parameters.(*generateParameters)
 	OUT := gp.out
 	generateFunction := gp.generateFunction
@@ -859,8 +1008,8 @@ func generatePerf(parameters interface{}, stopper chan int, report chan uint64, 
 			if pause == -1 {
 				// It is time to close this clone
 				close(stopper)
-				if context != nil {
-					context.Delete()
+				if context[0] != nil {
+					context[0].Delete()
 				}
 				// We don't close report channel because all clones of one function use it.
 				// As one function entity will be working endlessly we don't close it anywhere.
@@ -878,11 +1027,11 @@ func generatePerf(parameters interface{}, stopper chan int, report chan uint64, 
 				for i := range bufs {
 					// TODO Maybe we need to prefetcht here?
 					tempPacket = packet.ExtractPacket(bufs[i])
-					generateFunction(tempPacket, context)
+					generateFunction(tempPacket, context[0])
 				}
 			} else {
 				packet.ExtractPackets(tempPackets, bufs, burstSize)
-				vectorGenerateFunction(tempPackets, burstSize, context)
+				vectorGenerateFunction(tempPackets, burstSize, context[0])
 			}
 			safeEnqueue(OUT, bufs, burstSize)
 			currentSpeed = currentSpeed + uint64(burstSize)
@@ -899,7 +1048,7 @@ func generatePerf(parameters interface{}, stopper chan int, report chan uint64, 
 }
 
 // TODO reassembled packets are not supported
-func pcopy(parameters interface{}, stopper chan int, report chan uint64, context UserContext) {
+func pcopy(parameters interface{}, stopper chan int, report chan uint64, context []UserContext) {
 	cp := parameters.(*copyParameters)
 	IN := cp.in
 	OUT := cp.out
@@ -973,13 +1122,6 @@ func merge(from *low.Ring, to *low.Ring) {
 			if schedState.ff[i].Parameters.(*receiveParameters).out == from {
 				schedState.ff[i].Parameters.(*receiveParameters).out = to
 			}
-		case *partitionParameters:
-			if schedState.ff[i].Parameters.(*partitionParameters).outFirst == from {
-				schedState.ff[i].Parameters.(*partitionParameters).outFirst = to
-			}
-			if schedState.ff[i].Parameters.(*partitionParameters).outSecond == from {
-				schedState.ff[i].Parameters.(*partitionParameters).outSecond = to
-			}
 		case *generateParameters:
 			if schedState.ff[i].Parameters.(*generateParameters).out == from {
 				schedState.ff[i].Parameters.(*generateParameters).out = to
@@ -995,293 +1137,72 @@ func merge(from *low.Ring, to *low.Ring) {
 			if schedState.ff[i].Parameters.(*copyParameters).outCopy == from {
 				schedState.ff[i].Parameters.(*copyParameters).outCopy = to
 			}
-		case *splitParameters:
-			for j := uint(0); j < schedState.ff[i].Parameters.(*splitParameters).flowNumber; j++ {
-				if schedState.ff[i].Parameters.(*splitParameters).outs[j] == from {
-					schedState.ff[i].Parameters.(*splitParameters).outs[j] = to
-				}
-			}
-		case *separateParameters:
-			if schedState.ff[i].Parameters.(*separateParameters).outTrue == from {
-				schedState.ff[i].Parameters.(*separateParameters).outTrue = to
-			}
-			if schedState.ff[i].Parameters.(*separateParameters).outFalse == from {
-				schedState.ff[i].Parameters.(*separateParameters).outFalse = to
-			}
-		case *handleParameters:
-			if schedState.ff[i].Parameters.(*handleParameters).out == from {
-				schedState.ff[i].Parameters.(*handleParameters).out = to
+		}
+	}
+}
+
+func separate(packet *packet.Packet, sc *Func, ctx UserContext) uint {
+	if sc.sSeparateFunction(packet, ctx) == true {
+		return 0
+	}
+	return 1
+}
+
+func vSeparate(packets []*packet.Packet, mask *[burstSize]bool, answers *[burstSize]uint8, ve *Func, ctx UserContext) {
+	ve.vSeparateFunction(packets, mask, answers, ctx)
+}
+
+// partition doesn't need packets - just mbufs. However it will probably be
+// among other functions. So this overhead is not much.
+func partition(packet *packet.Packet, sc *Func, ctx UserContext) uint {
+	context := ctx.(*partitionCtx)
+	context.currentPacketNumber++
+	if context.currentPacketNumber == context.currentCompare {
+		context.currentAnswer = context.currentAnswer ^ 1
+		context.currentCompare = context.N + context.M - context.currentCompare
+		context.currentPacketNumber = 0
+	}
+	return uint(context.currentAnswer)
+}
+
+func vPartition(packets []*packet.Packet, mask *[burstSize]bool, answers *[burstSize]uint8, ve *Func, ctx UserContext) {
+	context := ctx.(*partitionCtx)
+	for i := 0; i < burstSize; i++ {
+		if (*mask)[i] {
+			context.currentPacketNumber++
+			if context.currentPacketNumber == context.currentCompare {
+				context.currentAnswer = context.currentAnswer ^ 1
+				context.currentCompare = context.N + context.M - context.currentCompare
+				context.currentPacketNumber = 0
+				answers[i] = context.currentAnswer
 			}
 		}
 	}
 }
 
-func separate(parameters interface{}, stopper chan int, report chan uint64, context UserContext) {
-	sp := parameters.(*separateParameters)
-	IN := sp.in
-	OUTTrue := sp.outTrue
-	OUTFalse := sp.outFalse
-	separateFunction := sp.separateFunction
-	vectorSeparateFunction := sp.vectorSeparateFunction
-	vector := (vectorSeparateFunction != nil)
-
-	bufsIn := make([]uintptr, burstSize)
-	bufsTrue := make([]uintptr, burstSize)
-	bufsFalse := make([]uintptr, burstSize)
-	ttt := make([]bool, burstSize)
-	var countOfPackets uint
-	var tempPacket *packet.Packet
-	var tempPacketAddr uintptr
-	tempPackets := make([]*packet.Packet, burstSize)
-	var currentSpeed uint64
-	tick := time.Tick(time.Duration(schedTime) * time.Millisecond)
-	var pause int
-
-	for {
-		select {
-		case pause = <-stopper:
-			if pause == -1 {
-				// It is time to close this clone
-				close(stopper)
-				if context != nil {
-					context.Delete()
-				}
-				// We don't close report channel because all clones of one function use it.
-				// As one function entity will be working endlessly we don't close it anywhere.
-				return
-			}
-		case <-tick:
-			report <- currentSpeed
-			currentSpeed = 0
-		default:
-			n := IN.DequeueBurst(bufsIn, burstSize)
-			if n == 0 {
-				if pause != 0 {
-					time.Sleep(time.Duration(pause) * time.Nanosecond)
-				}
-				continue
-			}
-			countOfPackets = 0
-			if vector == false {
-				tempPacketAddr = packet.ExtractPacketAddr(bufsIn[0])
-				// TODO here and in following flow functions: Now prefetch by zero address is
-				// slowing down the application. However we should use it in the future instead of code duplication.
-				for i := uint(0); i < n-1; i++ {
-					tempPacket = packet.ToPacket(tempPacketAddr)
-					tempPacketAddr = packet.ExtractPacketAddr(bufsIn[i+1])
-					asm.Prefetcht0(tempPacketAddr)
-					if separateFunction(tempPacket, context) == false {
-						bufsFalse[countOfPackets] = bufsIn[i]
-						countOfPackets++
-					} else {
-						bufsTrue[uint(i)-countOfPackets] = bufsIn[i]
-					}
-				}
-				if separateFunction(packet.ToPacket(tempPacketAddr), context) == false {
-					bufsFalse[countOfPackets] = bufsIn[n-1]
-					countOfPackets++
-				} else {
-					bufsTrue[uint(n-1)-countOfPackets] = bufsIn[n-1]
-				}
-			} else {
-				// TODO add prefetch for vector functions
-				packet.ExtractPackets(tempPackets, bufsIn, n)
-				vectorSeparateFunction(tempPackets, ttt, n, context)
-				for i := uint(0); i < n; i++ {
-					if ttt[i] == false {
-						bufsFalse[countOfPackets] = bufsIn[i]
-						countOfPackets++
-					} else {
-						bufsTrue[uint(i)-countOfPackets] = bufsIn[i]
-					}
-				}
-			}
-			if countOfPackets != 0 {
-				safeEnqueue(OUTFalse, bufsFalse, countOfPackets)
-			}
-			if countOfPackets != uint(n) {
-				c := n - countOfPackets
-				safeEnqueue(OUTTrue, bufsTrue, uint(c))
-			}
-			currentSpeed += uint64(n)
-		}
-	}
+func split(packet *packet.Packet, sc *Func, ctx UserContext) uint {
+	return sc.sSplitFunction(packet, ctx)
 }
 
-func partition(parameters interface{}) {
-	cp := parameters.(*partitionParameters)
-	IN := cp.in
-	OUTFirst := cp.outFirst
-	OUTSecond := cp.outSecond
-	N := cp.N
-	M := cp.M
-
-	bufsIn := make([]uintptr, burstSize)
-	bufsFirst := make([]uintptr, burstSize)
-	bufsSecond := make([]uintptr, burstSize)
-	var countOfPackets uint
-	currentPacketNumber := uint64(0)
-	sw := true
-	for {
-		n := IN.DequeueBurst(bufsIn, burstSize)
-		if n == 0 {
-			continue
-		}
-		countOfPackets = 0
-		for i := uint(0); i < n; i++ {
-			currentPacketNumber++
-			if sw == true {
-				bufsFirst[countOfPackets] = bufsIn[i]
-				countOfPackets++
-				if currentPacketNumber == N {
-					sw = false
-					currentPacketNumber = 0
-				}
-			} else {
-				bufsSecond[uint(i)-countOfPackets] = bufsIn[i]
-				if currentPacketNumber == M {
-					sw = true
-					currentPacketNumber = 0
-				}
-			}
-		}
-		if countOfPackets != 0 {
-			safeEnqueue(OUTFirst, bufsFirst, countOfPackets)
-		}
-		if countOfPackets != uint(n) {
-			c := n - countOfPackets
-			safeEnqueue(OUTSecond, bufsSecond, uint(c))
-		}
-	}
+func vSplit(packets []*packet.Packet, mask *[burstSize]bool, answers *[burstSize]uint8, ve *Func, ctx UserContext) {
+	ve.vSplitFunction(packets, mask, answers, ctx)
 }
 
-func split(parameters interface{}, stopper chan int, report chan uint64, context UserContext) {
-	sp := parameters.(*splitParameters)
-	IN := sp.in
-	OUT := sp.outs
-	splitFunction := sp.splitFunction
-	flowNumber := sp.flowNumber
-
-	InputMbufs := make([]uintptr, burstSize)
-	OutputMbufs := make([][]uintptr, flowNumber)
-	countOfPackets := make([]int, flowNumber)
-	for index := range OutputMbufs {
-		OutputMbufs[index] = make([]uintptr, burstSize)
-		countOfPackets[index] = 0
-	}
-	var tempPacket *packet.Packet
-	var tempPacketAddr uintptr
-	var currentSpeed uint64
-	tick := time.Tick(time.Duration(schedTime) * time.Millisecond)
-	var pause int
-
-	for {
-		select {
-		case pause = <-stopper:
-			if pause == -1 {
-				// It is time to close this clone
-				close(stopper)
-				if context != nil {
-					context.Delete()
-				}
-				// We don't close report channel because all clones of one function use it.
-				// As one function entity will be working endlessly we don't close it anywhere.
-				return
-			}
-		case <-tick:
-			report <- currentSpeed
-			currentSpeed = 0
-		default:
-			n := IN.DequeueBurst(InputMbufs, burstSize)
-			if n == 0 {
-				if pause != 0 {
-					time.Sleep(time.Duration(pause) * time.Nanosecond)
-				}
-				continue
-			}
-			tempPacketAddr = packet.ExtractPacketAddr(InputMbufs[0])
-			for i := uint(0); i < n-1; i++ {
-				tempPacket = packet.ToPacket(tempPacketAddr)
-				tempPacketAddr = packet.ExtractPacketAddr(InputMbufs[i+1])
-				asm.Prefetcht0(tempPacketAddr)
-				index := splitFunction(tempPacket, context)
-				OutputMbufs[index][countOfPackets[index]] = InputMbufs[i]
-				countOfPackets[index]++
-			}
-			index := splitFunction(packet.ToPacket(tempPacketAddr), context)
-			OutputMbufs[index][countOfPackets[index]] = InputMbufs[n-1]
-			countOfPackets[index]++
-
-			for index := uint(0); index < flowNumber; index++ {
-				if countOfPackets[index] == 0 {
-					continue
-				}
-				safeEnqueue(OUT[index], OutputMbufs[index], uint(countOfPackets[index]))
-				currentSpeed += uint64(countOfPackets[index])
-				countOfPackets[index] = 0
-			}
-		}
-	}
+func handle(packet *packet.Packet, sc *Func, ctx UserContext) uint {
+	sc.sHandleFunction(packet, ctx)
+	return 0
 }
 
-func handle(parameters interface{}, stopper chan int, report chan uint64, context UserContext) {
-	sp := parameters.(*handleParameters)
-	IN := sp.in
-	OUT := sp.out
-	handleFunction := sp.handleFunction
-	vectorHandleFunction := sp.vectorHandleFunction
-	vector := (vectorHandleFunction != nil)
+func vHandle(packets []*packet.Packet, mask *[burstSize]bool, answers *[burstSize]uint8, ve *Func, ctx UserContext) {
+	ve.vHandleFunction(packets, mask, ctx)
+}
 
-	bufs := make([]uintptr, burstSize)
-	var tempPacket *packet.Packet
-	var tempPacketAddr uintptr
-	tempPackets := make([]*packet.Packet, burstSize)
-	var currentSpeed uint64
-	tick := time.Tick(time.Duration(schedTime) * time.Millisecond)
-	var pause int
+func constructSlice(packet *packet.Packet, sc *Func, ctx UserContext) uint {
+	return sc.bufIndex
+}
 
-	for {
-		select {
-		case pause = <-stopper:
-			if pause == -1 {
-				// It is time to close this clone
-				close(stopper)
-				if context != nil {
-					context.Delete()
-				}
-				// We don't close report channel because all clones of one function use it.
-				// As one function entity will be working endlessly we don't close it anywhere.
-				return
-			}
-		case <-tick:
-			report <- currentSpeed
-			currentSpeed = 0
-		default:
-			n := IN.DequeueBurst(bufs, burstSize)
-			if n == 0 {
-				if pause != 0 {
-					time.Sleep(time.Duration(pause) * time.Nanosecond)
-				}
-				continue
-			}
-			if vector == false {
-				tempPacketAddr = packet.ExtractPacketAddr(bufs[0])
-				for i := uint(0); i < n-1; i++ {
-					tempPacket = packet.ToPacket(tempPacketAddr)
-					tempPacketAddr = packet.ExtractPacketAddr(bufs[i+1])
-					asm.Prefetcht0(tempPacketAddr)
-					handleFunction(tempPacket, context)
-				}
-				handleFunction(packet.ToPacket(tempPacketAddr), context)
-			} else {
-				// TODO add prefetch for vector functions
-				packet.ExtractPackets(tempPackets, bufs, n)
-				vectorHandleFunction(tempPackets, n, context)
-			}
-			safeEnqueue(OUT, bufs, uint(n))
-			currentSpeed += uint64(n)
-		}
-	}
+func vConstructSlice(packets []*packet.Packet, mask *[burstSize]bool, answers *[burstSize]uint8, ve *Func, ctx UserContext) {
+	answers[0] = uint8(ve.bufIndex)
 }
 
 func write(parameters interface{}) {
@@ -1395,7 +1316,7 @@ func checkFlow(f *Flow) error {
 	if f == nil {
 		return common.WrapWithNFError(nil, "One of the flows is nil!", common.UseNilFlowErr)
 	}
-	if f.current == nil {
+	if f.current == nil && f.previous == nil {
 		return common.WrapWithNFError(nil, "One of the flows is used after it was closed!", common.UseClosedFlowErr)
 	}
 	return nil
@@ -1410,4 +1331,15 @@ func CreateKniDevice(portId uint8, core uint8, name string) *Kni {
 	// KNI structure itself is stored inside low.c
 	kni.portId = portId
 	return kni
+}
+
+func FillSliceFromMask(input []uintptr, mask *[burstSize]bool, output []uintptr) uint8 {
+	count := 0
+	for i := 0; i < burstSize; i++ {
+		if (*mask)[i] != false {
+			output[count] = input[i]
+			count++
+		}
+	}
+	return uint8(count)
 }


### PR DESCRIPTION
Changes short:
1) Sequential segments of functions handle, split, separate and partition are now
- invocated at one core
- clonned simultaneously
- don't use any rings and mbuf inside them
2) Vector functions use mask instead of packets regrouping
3) Partition is now clonnable function

Changes long:
Flow graph is now divided into four parts.
1) "Get" functions: Receive, Receive from KNI, Receive from File, Generate, Fast generate
2) "Copy" function: Copy
3) "Segment" functions: Handle, Separate, Split, Partition
4) "Set" functions: Send, Send to KNI, Send to file, Stop
1 - is always the first.
2 - can be after 1 or 3
3 - can be after 1 or 2
4 - can be after 1, 2 or any function from 3 group
Merge function interrupts sequential segment and can be placed wherever user wants
Transitions between Scalar and vector code also interrupts segment

--------------------

Performance results for our four main parameters are the following:

Mb/s, no scheduler - drop significantly. Can't compare this directly, because all handling is at one core now. Reduction is expected.

Cores number, no scheduler - drop by 1 at non sequential tests (handle + partition were combined). Dropped significantly at sequential tests (sequential handles + final partition combined)

Mb/s, scheduler - increased by 5.85% in geomean. Lot's more increasing in sequential tests including NAT. Performance of lighter test not significantly drop (need to be investigated)

Cores number, scheduler - drop by 6.06% geomean. Significantly dropped at sequential tests. Slightly increased at NAT.

Latency dropped because our tests checked it without cloning. This means that earlier we have four sequential cores with handles per test which which worked as pipeline. Now we have only one core and latency increases.