### PR TITLE
Switched vagrant script to work with libvirt

### DIFF
--- a/vagrant/.gitignore
+++ b/vagrant/.gitignore
@@ -1,2 +1,3 @@
 *.log
 .vagrant
+config.ssh

--- a/vagrant/README.md
+++ b/vagrant/README.md
@@ -1,16 +1,11 @@
-To execute vagrant with this Vagrantfile it is recommended to use
-VirtualBox 5.2 or higher and vagrant 2.0.1 or higher. Additionally, if
-you use http proxy, it is necessary to install vagrant proxyconf
-plugin.
-
-Use this page to add VirtualBox repository to your Linux installation
-https://www.virtualbox.org/wiki/Linux_Downloads
+For VM specific section see below. Libvirt is the default VM now and
+it requires an additional vagrant plugin.
 
 Download Vagrant installation package from this page
 https://www.vagrantup.com/downloads.html. For Ubuntu use Debian .deb
 file and install it with command
 
-        sudo dpkg -i vagrant_2.0.1_x86_64.deb
+        sudo dpkg -i vagrant_2.0.3_x86_64.deb
 
 A plugin is required to restart VMs after provisioning:
 
@@ -48,3 +43,39 @@ single link: VM-VM-VM VM-VM.
 See wiki page https://github.com/intel-go/nff-go/wiki/NAT-example for
 instructions on how to configure virtual machines to run NFF-GO NAT
 example.
+
+## Libvirt/Qemu/KVM specific secion
+
+It is necessary to install libvirt vagrant plugin like this:
+
+    vagrant plugin install vagrant-libvirt
+
+Current setup creates VM in storage pool named 'images'. To create
+such pool use commands like this:
+
+    virsh pool-define-as images dir --target /localdisk/libvirt
+    virsh pool-start images
+
+VMs are connected via virtual networks which are created as UDP
+tunnes. For this it is necessary to allocate a sufficient number of
+UDP ports on localhost. Default port starting number is 12345. After
+this port VMs use ports continuously with total number equal to
+(VM_LINKS_NUMBER+1)*VM_TOTAL_NUMBER. If any of these ports are already
+occupied (e.g. some other use already created VMs with this starting
+port number), some network connections will not work. To change
+starting port number you can define VM_TUNNEL_PORT_BASE variable
+before using 'vagrant up' command.
+
+## VirtualBox specific section
+
+In our experience VirtualBox hangs and crashes too often. Its Intel
+network cards emulation doesn't support VLAN tags. That is why we had
+to switch to Libvirt/Qemu/KVM alternative.
+
+To execute vagrant with this Vagrantfile it is recommended to use
+VirtualBox 5.2 or higher and vagrant 2.0.1 or higher. Additionally, if
+you use http proxy, it is necessary to install vagrant proxyconf
+plugin.
+
+Use this page to add VirtualBox repository to your Linux installation
+https://www.virtualbox.org/wiki/Linux_Downloads

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -12,13 +12,20 @@ Vagrant.configure(2) do |config|
     config.proxy.no_proxy = ENV.fetch('no_proxy', false)
   end
 
+  if ENV['HOME']
+    storage_path = ENV.fetch('HOME') + "/.local/share/libvirt/images"
+  else
+    storage_path = "/var/lib/libvirt/images"
+  end
   vm_name = ENV.fetch('VM_NAME', "nff-go")
   vm_group_size = ENV.fetch('VM_GROUP_SIZE', 3).to_i
   vm_total_number = ENV.fetch("VM_TOTAL_NUMBER", 3).to_i
   vm_links_number = ENV.fetch("VM_LINKS_NUMBER", 2).to_i
+  vm_port_base = ENV.fetch("VM_TUNNEL_PORT_BASE", 12345).to_i
+  vm_second_port_base = vm_port_base + (vm_links_number + 1) * vm_total_number
 
 #  config.vm.box = "ubuntu/xenial64"
-  config.vm.box = "generic/fedora27"
+  config.vm.box = "fedora/27-cloud-base"
 
   # Docker server port
   config.vm.network "forwarded_port", guest: 2375, host: 2375, auto_correct: true
@@ -27,6 +34,13 @@ Vagrant.configure(2) do |config|
   # boxes will only be checked for updates when the user runs
   # `vagrant box outdated`. This is not recommended.
   config.vm.box_check_update = false
+
+  config.vm.provider "libvirt" do |lv|
+    lv.driver = "kvm"
+    lv.memory = "4096"
+    lv.cpus = 8
+    lv.storage_pool_name = "images"
+  end
 
   config.vm.provider "virtualbox" do |vb|
     vb.gui = false
@@ -38,13 +52,11 @@ Vagrant.configure(2) do |config|
   end
 
 $provision_fedora = <<SHELL
-echo Fixing bootloader to use consistent interface names
-sudo sed -i -e 's,biosdevname=0 net.ifnames=0 ,,' /etc/default/grub
-sudo grub2-mkconfig -o /boot/grub2/grub.cfg
-
 echo Installing system packages
-sudo dnf update
-sudo dnf install -y redhat-lsb-core net-tools numactl-devel libpcap-devel elfutils-libelf-devel
+sudo dnf update -y
+sudo dnf install -y python make gcc git numactl-devel libpcap-devel elfutils-libelf-devel NetworkManager net-tools redhat-lsb-core pciutils kernel-modules kernel-devel wget vim
+sudo systemctl enable NetworkManager
+sudo systemctl start NetworkManager
 SHELL
 
 $provision_ubuntu = <<SHELL
@@ -57,7 +69,7 @@ SHELL
 
 $provision_common = <<SHELL
 echo Unpacking Go language into /opt
-(cd /opt; sudo sh -c 'curl -L -s https://dl.google.com/go/go1.9.4.linux-amd64.tar.gz | tar zx')
+(cd /opt; sudo sh -c 'curl -L -s https://dl.google.com/go/go1.10.1.linux-amd64.tar.gz | tar zx')
 mkdir go
 chmod +x ~/scripts.sh
 . ~/scripts.sh
@@ -77,10 +89,13 @@ SHELL
   # Enable provisioning with a shell script. Additional provisioners such as
   # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
   # documentation for more information about their specific syntax and use.
-  config.vm.provision "shell", privileged: false, inline: $provision_fedora + $provision_common
+  config.vm.provision "shell", privileged: false, inline: $provision_fedora
   # Optional Ubuntu provisioning, use if you want to work in Ubuntu
   # environment.
-  config.vm.provision "shell", privileged: false, run: "never", inline: $provision_ubuntu + $provision_common
+  config.vm.provision "shell", privileged: false, run: "never", inline: $provision_ubuntu
+  # Reboot VM after distro specific provisioning
+  config.vm.provision :reload
+  config.vm.provision "shell", privileged: false, inline: $provision_common
   # Reboot VM after provisioning
   config.vm.provision :reload
 
@@ -94,9 +109,27 @@ SHELL
       if i % vm_group_size != 0
         # Define backward inter-VM virtual network links
         (1..vm_links_number).each do |j|
-          node.vm.network "private_network",
-                          auto_config: false,
-                          virtualbox__intnet: "#{vm_name}-link-#{user}-#{i}-#{j}"
+          if (i % vm_group_size) == vm_group_size - 1 && j == 1
+            # Workaround hardcoded MAC address for server VM until we implement ARP completely
+            node.vm.network "private_network",
+                            auto_config: false,
+                            virtualbox__intnet: "#{vm_name}-link-#{user}-#{i}-#{j}",
+                            :mac => '3c:fd:fe:a4:dd:f0',
+                            :model_type => 'e1000',
+                            :libvirt__forward_mode => 'none',
+                            :libvirt__tunnel_type => 'udp',
+                            :libvirt__tunnel_local_port => vm_second_port_base + i * vm_links_number + j,
+                            :libvirt__tunnel_port => vm_port_base + i * vm_links_number + j
+          else
+            node.vm.network "private_network",
+                            auto_config: false,
+                            virtualbox__intnet: "#{vm_name}-link-#{user}-#{i}-#{j}",
+                            :model_type => 'e1000',
+                            :libvirt__forward_mode => 'none',
+                            :libvirt__tunnel_type => 'udp',
+                            :libvirt__tunnel_local_port => vm_second_port_base + i * vm_links_number + j,
+                            :libvirt__tunnel_port => vm_port_base + i * vm_links_number + j
+          end
         end
       end
 
@@ -105,7 +138,12 @@ SHELL
         (1..vm_links_number).each do |j|
           node.vm.network "private_network",
                           auto_config: false,
-                          virtualbox__intnet: "#{vm_name}-link-#{user}-#{i + 1}-#{j}"
+                          virtualbox__intnet: "#{vm_name}-link-#{user}-#{i + 1}-#{j}",
+                          :model_type => 'e1000',
+                          :libvirt__forward_mode => 'none',
+                          :libvirt__tunnel_type => 'udp',
+                          :libvirt__tunnel_local_port => vm_port_base + (i + 1) * vm_links_number + j,
+                          :libvirt__tunnel_port => vm_second_port_base + (i + 1) * vm_links_number + j
         end
       end
     end

--- a/vagrant/getports.sh
+++ b/vagrant/getports.sh
@@ -3,8 +3,8 @@
 if (( "$#" != 1 ))
 then
     echo Usage: \$\(./getports.sh \<port number\>\)
-    echo Script generates \$sp0, \$sp1, etc variables if specified port is 22, and generates
-    echo \$dp0, \$dp1, etc if specified port is 2375.
+    echo Script generates \$sc0, \$sc1, etc variables if specified port is 22, and generates
+    echo \$da0, \$da1, etc if specified port is 2375.
     echo If specified port is 2375, script also generates NFF_GO_HOSTS variable.
     echo
     echo If VM_TOTAL_NUMBER is set, it is used as a number of VMs, otherwise 2 is used.
@@ -13,18 +13,6 @@ then
 fi
 
 port_number=$1
-
-if [ "${port_number}" == 22 ]
-then
-   pp="sp"
-elif [ "${port_number}" == 2375 ]
-then
-    hosts=""
-    pp="dp"
-else
-    echo Unknown port specified ${port_number}
-    exit 1
-fi
 
 if [ -z "${VM_NAME}" ]
 then
@@ -35,26 +23,59 @@ fi
 
 if [ -z "${VM_TOTAL_NUMBER}" ]
 then
-    number=2
+    number=3
 else
     number=${VM_TOTAL_NUMBER}
 fi
 
-for (( i=0; i<${number}; i++ ))
-do
-    port=$(vagrant port --guest ${port_number} ${vm_prefix}${i})
-    echo export ${pp}${i}=${port}
-    if [ "${port_number}" == 2375 ]
-    then
-        if (( i>0 ))
+if [ "${port_number}" == 22 ]
+then
+   pp="sc"
+   vagrant ssh-config > $(pwd)/config.ssh
+   for (( i=0; i<${number}; i++ ))
+   do
+       echo export ${pp}${i}=$(pwd)/config.ssh
+   done
+elif [ "${port_number}" == 2375 ]
+then
+    hosts=""
+    np_hosts=""
+    pp="da"
+    status=$(vagrant status)
+    for (( i=0; i<${number}; i++ ))
+    do
+        vm_name=${vm_prefix}${i}
+        if echo "${status}" | grep ${vm_name} | grep -q libvirt
         then
-            hosts=${hosts},
+            config=$(vagrant ssh-config ${vm_name})
+            address=$(echo "${config}" | grep HostName | cut -d " " -f 4)
+            port=${port_number}
+        elif echo "${status}" | grep ${vm_name} | grep -q virtualbox
+        then
+            address=localhost
+            port=$(vagrant port --guest ${port_number} ${vm_name})
+        else
+            echo Unknown provider for VM ${vm_name}
+            break
         fi
-        hosts=${hosts}localhost:${port}
-    fi
-done
+
+        echo export ${pp}${i}=${address}:${port}
+        if (( i==0 ))
+        then
+            hosts=${address}:${port}
+            np_hosts=${address}
+        else
+            hosts=${hosts},${address}:${port}
+            np_hosts=${np_hosts},${address}
+        fi
+    done
+else
+    echo Unknown port specified ${port_number}
+    exit 1
+fi
 
 if [ "${port_number}" == 2375 ]
 then
     echo export NFF_GO_HOSTS=${hosts}
+    echo export no_proxy=${np_hosts}
 fi


### PR DESCRIPTION
An attempt has been made to preserve functioning VirtualBox
provisioning, but it wasn't tested. Updated getports script and README
with instructions on how to create reference set of VMs using libvirt.