### PR TITLE
fix vector functions

### DIFF
--- a/examples/tutorial/step10.go
+++ b/examples/tutorial/step10.go
@@ -41,7 +41,7 @@ func mySplitter(cur *packet.Packet, ctx flow.UserContext) uint {
 }
 
 func myHandler(curV []*packet.Packet, mask *[vecSize]bool, ctx flow.UserContext) {
-	for i := uint(0); i < 32; i++ {
+	for i := uint(0); i < vecSize; i++ {
 		if (*mask)[i] == true {
 			cur := curV[i]
 			cur.EncapsulateHead(common.EtherLen, common.IPv4MinLen)

--- a/examples/tutorial/step11.go
+++ b/examples/tutorial/step11.go
@@ -41,7 +41,7 @@ func mySplitter(cur *packet.Packet, ctx flow.UserContext) uint {
 }
 
 func myHandler(curV []*packet.Packet, mask *[vecSize]bool, ctx flow.UserContext) {
-	for i := uint(0); i < 32; i++ {
+	for i := uint(0); i < vecSize; i++ {
 		if (*mask)[i] == true {
 			cur := curV[i]
 			cur.EncapsulateHead(common.EtherLen, common.IPv4MinLen)

--- a/low/low.go
+++ b/low/low.go
@@ -636,3 +636,11 @@ func DeleteLPMRule(lpm unsafe.Pointer, ip uint32, depth uint8) int {
 func FreeLPM(lpm unsafe.Pointer) {
 	C.lpm_free(lpm)
 }
+
+func BoolToInt(value bool) uint8 {
+	return *((*uint8)(unsafe.Pointer(&value)))
+}
+
+func IntArrayToBool(value *[32]uint8) *[32]bool {
+        return (*[32]bool)(unsafe.Pointer(value))
+}


### PR DESCRIPTION
1) When we preserve flow after flow function it was always zero answer of this function. It is wrong for separate which remain packets in preserved flow in "true" answer. So this default parameter was changed to variable parameter in segmentInsert function.

2) Vector logic in main loop was absolutely wrong - correct it.

3) Vector separate now has boolean type of answers which is more logical because our firewall functions return boolean instead of uint8