### PR TITLE
Make KNI more user friendly

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -139,6 +139,7 @@ const (
 	InvalidCPURangeErr
 	SetAffinityErr
 	MultipleReceivePort
+	MultipleKNIPort
 )
 
 // NFError is error type returned by nff-go functions

--- a/examples/kni.go
+++ b/examples/kni.go
@@ -20,8 +20,9 @@ func main() {
 	}
 
 	flow.CheckFatal(flow.SystemInit(&config))
-	// (port of device, core (not from NFF-GO set) which will handle device, name of device)
-	kni := flow.CreateKniDevice(0, 20, "myKNI")
+	// (port of device, name of device)
+	kni, err := flow.CreateKniDevice(0, "myKNI")
+	flow.CheckFatal(err)
 
 	fromEthFlow, err := flow.SetReceiver(0)
 	flow.CheckFatal(err)

--- a/low/low.go
+++ b/low/low.go
@@ -439,7 +439,7 @@ func (ring *Ring) GetRingCount() uint32 {
 // Receive - get packets and enqueue on a Ring.
 func Receive(port uint16, queue int16, OUT *Ring, flag *int32, coreID int) {
 	t := C.rte_eth_dev_socket_id(C.uint16_t(port))
-	if t != C.int(C.rte_lcore_to_socket_id(C.uint(coreID))) {
+	if queue != -1 && t != C.int(C.rte_lcore_to_socket_id(C.uint(coreID))) {
 		common.LogWarning(common.Initialization, "Receive port", port, "is on remote NUMA node to polling thread - not optimal performance.")
 	}
 	C.nff_go_recv(C.uint16_t(port), C.int16_t(queue), OUT.DPDK_ring, (*C.int)(unsafe.Pointer(flag)), C.int(coreID))
@@ -448,7 +448,7 @@ func Receive(port uint16, queue int16, OUT *Ring, flag *int32, coreID int) {
 // Send - dequeue packets and send.
 func Send(port uint16, queue int16, IN *Ring, flag *int32, coreID int) {
 	t := C.rte_eth_dev_socket_id(C.uint16_t(port))
-	if t != C.int(C.rte_lcore_to_socket_id(C.uint(coreID))) {
+	if queue != -1 && t != C.int(C.rte_lcore_to_socket_id(C.uint(coreID))) {
 		common.LogWarning(common.Initialization, "Send port", port, "is on remote NUMA node to polling thread - not optimal performance.")
 	}
 	C.nff_go_send(C.uint16_t(port), C.int16_t(queue), IN.DPDK_ring, (*C.int)(unsafe.Pointer(flag)), C.int(coreID))
@@ -604,10 +604,10 @@ func ReportMempoolsState() {
 }
 
 // CreateKni creates a KNI device
-func CreateKni(portId uint16, core uint8, name string) {
+func CreateKni(portId uint16, core uint, name string) {
 	mempool := C.createMempool(C.uint32_t(mbufNumberT), C.uint32_t(mbufCacheSizeT))
 	usedMempools = append(usedMempools, mempool)
-	C.create_kni(C.uint16_t(portId), C.uint8_t(core), C.CString(name), mempool)
+	C.create_kni(C.uint16_t(portId), C.uint32_t(core), C.CString(name), mempool)
 }
 
 // CreateLPM creates LPM table


### PR DESCRIPTION
Remove core parameter from KNI allocation - now it is automatic
Add KNI port existence and port duplication checkings
Remove default callbacks - they need expensive synchronization