### PR TITLE
Eliminate overriding recipe while make

### DIFF
--- a/common/Makefile
+++ b/common/Makefile
@@ -6,7 +6,7 @@ PATH_TO_MK = ../mk
 include $(PATH_TO_MK)/include.mk
 
 .PHONY: testing
-testing:
+testing: check-pktgen
 	go test
 
 .PHONY: coverage

--- a/low/Makefile
+++ b/low/Makefile
@@ -6,5 +6,5 @@ PATH_TO_MK = ../mk
 include $(PATH_TO_MK)/include.mk
 
 .PHONY: testing
-testing:
+testing: check-pktgen
 	go test

--- a/mk/intermediate.mk
+++ b/mk/intermediate.mk
@@ -2,8 +2,6 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-include $(PATH_TO_MK)/include.mk
-
 TARGETS = all clean images clean-images deploy cleanall
 .PHONY: $(TARGETS) $(SUBDIRS)
 

--- a/test/stability/Makefile
+++ b/test/stability/Makefile
@@ -5,9 +5,9 @@
 PATH_TO_MK = ../../mk
 SUBDIRS = testMerge testSingleWorkingFF testCksum
 
+include $(PATH_TO_MK)/intermediate.mk
+
 testing:
 	for dir in $(SUBDIRS); do \
 		cd $$dir && make testing; cd -; \
 	done
-
-include $(PATH_TO_MK)/intermediate.mk

--- a/test/stability/testCksum/Makefile
+++ b/test/stability/testCksum/Makefile
@@ -6,7 +6,7 @@ PATH_TO_MK = ../../../mk
 IMAGENAME = nff-go-test-cksum
 EXECUTABLES = testCksum
 
-testing:
+testing: check-pktgen
 	go test
 
 include $(PATH_TO_MK)/leaf.mk

--- a/test/stability/testMerge/Makefile
+++ b/test/stability/testMerge/Makefile
@@ -9,7 +9,7 @@ EXECUTABLES = testMerge
 all:
 	cp ../../framework/main/config.json .
 
-testing:
+testing: check-pktgen
 	go test
 
 include $(PATH_TO_MK)/leaf.mk

--- a/test/stability/testSingleWorkingFF/Makefile
+++ b/test/stability/testSingleWorkingFF/Makefile
@@ -9,8 +9,7 @@ EXECUTABLES = testSingleWorkingFF
 all:
 	cp ../../framework/main/config.json .
 
-# We can't test them together because our system won't stop handlers between tests
-testing:
+testing: check-pktgen
 	go test
 
 include $(PATH_TO_MK)/leaf.mk


### PR DESCRIPTION
The main change is removing include.mk from intermediate.mk. This include leads to duplication in example directory, confusing warnings and debug messages because examples directory is considered both leaf and intermediate with both includes. When both of them include include.mk - it was duplication.