### PR TITLE
Added default value for variable cause it was not set by gotest and failed.

### DIFF
--- a/test/stability/testCksum/testCksum.go
+++ b/test/stability/testCksum/testCksum.go
@@ -77,7 +77,7 @@ var (
 	packetLength int
 	ipVersion    uint   = 4
 	tci          uint16 = 2
-	dpdkLogLevel string
+	dpdkLogLevel = "--log-level=0"
 	protocol     = stabilityCommon.TypeUdp
 )
 

--- a/test/stability/testMerge/testMerge.go
+++ b/test/stability/testMerge/testMerge.go
@@ -65,7 +65,7 @@ var (
 	outport2     uint
 	inport1      uint
 	inport2      uint
-	dpdkLogLevel string
+	dpdkLogLevel = "--log-level=0"
 
 	fixMACAddrs  func(*packet.Packet, flow.UserContext)
 	fixMACAddrs1 func(*packet.Packet, flow.UserContext)

--- a/test/stability/testSingleWorkingFF/testSingleWorkingFF.go
+++ b/test/stability/testSingleWorkingFF/testSingleWorkingFF.go
@@ -83,7 +83,7 @@ var (
 	outport2     uint
 	inport1      uint
 	inport2      uint
-	dpdkLogLevel string
+	dpdkLogLevel = "--log-level=0"
 
 	fixMACAddrs  func(*packet.Packet, flow.UserContext)
 	fixMACAddrs1 func(*packet.Packet, flow.UserContext)


### PR DESCRIPTION
Tests that can be run by gotest should have this initialization. 