### PR TITLE
More strictly tests

### DIFF
--- a/test/framework/main/stability-VM.json
+++ b/test/framework/main/stability-VM.json
@@ -39,14 +39,14 @@
             "test-type": "TestTypeScenario",
             "test-apps": [
                 {
-                    "image-name": "nff-go-test-singleWorkingFF",
+                    "image-name": "nff-go-test-singleworkingff",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
                         "./testSingleWorkingFF", "-speed=10000", "-number=100000", "-testScenario=1", "-inport1=0", "-outport1=0", "-inport2=1", "-testType=2"
                     ]
                 },
                 {
-                    "image-name": "nff-go-test-singleWorkingFF",
+                    "image-name": "nff-go-test-singleworkingff",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
                         "./testSingleWorkingFF", "-testScenario=2", "-inport1=0", "-outport1=0", "-outport2=1", "-testType=2"
@@ -60,14 +60,14 @@
             "test-type": "TestTypeScenario",
             "test-apps": [
                 {
-                    "image-name": "nff-go-test-singleWorkingFF",
+                    "image-name": "nff-go-test-singleworkingff",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
                         "./testSingleWorkingFF", "-speed=10000", "-number=100000", "-testScenario=1", "-inport1=0", "-outport1=0", "-inport2=1", "-testType=3"
                     ]
                 },
                 {
-                    "image-name": "nff-go-test-singleWorkingFF",
+                    "image-name": "nff-go-test-singleworkingff",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
                         "./testSingleWorkingFF", "-testScenario=2", "-inport1=0", "-outport1=0", "-outport2=1", "-testType=3"
@@ -81,14 +81,14 @@
             "test-type": "TestTypeScenario",
             "test-apps": [
                 {
-                    "image-name": "nff-go-test-singleWorkingFF",
+                    "image-name": "nff-go-test-singleworkingff",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
                         "./testSingleWorkingFF", "-speed=10000", "-number=100000", "-testScenario=1", "-inport1=0", "-outport1=0", "-inport2=1", "-testType=0"
                     ]
                 },
                 {
-                    "image-name": "nff-go-test-singleWorkingFF",
+                    "image-name": "nff-go-test-singleworkingff",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
                         "./testSingleWorkingFF", "-testScenario=2", "-inport1=0", "-outport1=0", "-outport2=1", "-testType=0"
@@ -102,14 +102,14 @@
             "test-type": "TestTypeScenario",
             "test-apps": [
                 {
-                    "image-name": "nff-go-test-singleWorkingFF",
+                    "image-name": "nff-go-test-singleworkingff",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
                         "./testSingleWorkingFF", "-speed=10000", "-number=100000", "-testScenario=1", "-inport1=0", "-outport1=0", "-inport2=1", "-testType=1"
                     ]
                 },
                 {
-                    "image-name": "nff-go-test-singleWorkingFF",
+                    "image-name": "nff-go-test-singleworkingff",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
                         "./testSingleWorkingFF", "-testScenario=2", "-inport1=0", "-outport1=0", "-outport2=1", "-testType=1"
@@ -123,14 +123,14 @@
             "test-type": "TestTypeScenario",
             "test-apps": [
                 {
-                    "image-name": "nff-go-test-singleWorkingFF",
+                    "image-name": "nff-go-test-singleworkingff",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
                         "./testSingleWorkingFF", "-speed=10000", "-number=100000", "-testScenario=1", "-inport1=0", "-outport1=0", "-inport2=1", "-testType=4"
                     ]
                 },
                 {
-                    "image-name": "nff-go-test-singleWorkingFF",
+                    "image-name": "nff-go-test-singleworkingff",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
                         "./testSingleWorkingFF", "-testScenario=2", "-inport1=0", "-outport1=0", "-outport2=1", "-testType=4"
@@ -144,14 +144,14 @@
             "test-type": "TestTypeScenario",
             "test-apps": [
                 {
-                    "image-name": "nff-go-test-singleWorkingFF",
+                    "image-name": "nff-go-test-singleworkingff",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
                         "./testSingleWorkingFF", "-speed=10000", "-number=100000", "-testScenario=1", "-inport1=0", "-outport1=0", "-inport2=1", "-testType=5"
                     ]
                 },
                 {
-                    "image-name": "nff-go-test-singleWorkingFF",
+                    "image-name": "nff-go-test-singleworkingff",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
                         "./testSingleWorkingFF", "-testScenario=2", "-inport1=0", "-outport1=0", "-outport2=1", "-testType=5"
@@ -165,14 +165,14 @@
             "test-type": "TestTypeScenario",
             "test-apps": [
                 {
-                    "image-name": "nff-go-test-singleWorkingFF",
+                    "image-name": "nff-go-test-singleworkingff",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
                         "./testSingleWorkingFF", "-speed=10000", "-number=100000", "-testScenario=1", "-inport1=0", "-outport1=0", "-inport2=1", "-testType=6"
                     ]
                 },
                 {
-                    "image-name": "nff-go-test-singleWorkingFF",
+                    "image-name": "nff-go-test-singleworkingff",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
                         "./testSingleWorkingFF", "-testScenario=2", "-inport1=0", "-outport1=0", "-outport2=1", "-testType=6"
@@ -186,14 +186,14 @@
             "test-type": "TestTypeScenario",
             "test-apps": [
                 {
-                    "image-name": "nff-go-test-singleWorkingFF",
+                    "image-name": "nff-go-test-singleworkingff",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
                         "./testSingleWorkingFF", "-speed=10000", "-number=100000", "-testScenario=1", "-inport1=1", "-outport1=0", "-testType=8"
                     ]
                 },
                 {
-                    "image-name": "nff-go-test-singleWorkingFF",
+                    "image-name": "nff-go-test-singleworkingff",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
                         "./testSingleWorkingFF", "-testScenario=2", "-inport1=0", "-outport1=1", "-testType=8"
@@ -207,14 +207,14 @@
             "test-type": "TestTypeScenario",
             "test-apps": [
                 {
-                    "image-name": "nff-go-test-singleWorkingFF",
+                    "image-name": "nff-go-test-singleworkingff",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
                         "./testSingleWorkingFF", "-speed=10000", "-number=100000", "-testScenario=1", "-inport1=1", "-outport1=0", "-testType=9"
                     ]
                 },
                 {
-                    "image-name": "nff-go-test-singleWorkingFF",
+                    "image-name": "nff-go-test-singleworkingff",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
                         "./testSingleWorkingFF", "-testScenario=2", "-inport1=0", "-outport1=1", "-testType=9"
@@ -228,14 +228,14 @@
             "test-type": "TestTypeScenario",
             "test-apps": [
                 {
-                    "image-name": "nff-go-test-singleWorkingFF",
+                    "image-name": "nff-go-test-singleworkingff",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
                         "./testSingleWorkingFF", "-speed=10000", "-number=100000", "-testScenario=1", "-inport1=1", "-outport1=0", "-testType=10"
                     ]
                 },
                 {
-                    "image-name": "nff-go-test-singleWorkingFF",
+                    "image-name": "nff-go-test-singleworkingff",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
                         "./testSingleWorkingFF", "-testScenario=2", "-inport1=0", "-outport1=1", "-testType=10"
@@ -249,14 +249,14 @@
             "test-type": "TestTypeScenario",
             "test-apps": [
                 {
-                    "image-name": "nff-go-test-singleWorkingFF",
+                    "image-name": "nff-go-test-singleworkingff",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
                         "./testSingleWorkingFF", "-speed=10000", "-number=100000", "-testScenario=1", "-inport1=1", "-outport1=0", "-testType=11"
                     ]
                 },
                 {
-                    "image-name": "nff-go-test-singleWorkingFF",
+                    "image-name": "nff-go-test-singleworkingff",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
                         "./testSingleWorkingFF", "-testScenario=2", "-inport1=0", "-outport1=1", "-testType=11"

--- a/test/framework/main/stability.json
+++ b/test/framework/main/stability.json
@@ -39,14 +39,14 @@
             "test-type": "TestTypeScenario",
             "test-apps": [
                 {
-                    "image-name": "nff-go-test-singleWorkingFF",
+                    "image-name": "nff-go-test-singleworkingff",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
                         "./testSingleWorkingFF", "-speed=10000", "-number=100000", "-testScenario=1", "-inport1=0", "-outport1=0", "-inport2=1", "-testType=2"
                     ]
                 },
                 {
-                    "image-name": "nff-go-test-singleWorkingFF",
+                    "image-name": "nff-go-test-singleworkingff",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
                         "./testSingleWorkingFF", "-testScenario=2", "-inport1=0", "-outport1=0", "-outport2=1", "-testType=2"
@@ -60,14 +60,14 @@
             "test-type": "TestTypeScenario",
             "test-apps": [
                 {
-                    "image-name": "nff-go-test-singleWorkingFF",
+                    "image-name": "nff-go-test-singleworkingff",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
                         "./testSingleWorkingFF", "-speed=10000", "-number=100000", "-testScenario=1", "-inport1=0", "-outport1=0", "-inport2=1", "-testType=3"
                     ]
                 },
                 {
-                    "image-name": "nff-go-test-singleWorkingFF",
+                    "image-name": "nff-go-test-singleworkingff",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
                         "./testSingleWorkingFF", "-testScenario=2", "-inport1=0", "-outport1=0", "-outport2=1", "-testType=3"
@@ -81,14 +81,14 @@
             "test-type": "TestTypeScenario",
             "test-apps": [
                 {
-                    "image-name": "nff-go-test-singleWorkingFF",
+                    "image-name": "nff-go-test-singleworkingff",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
                         "./testSingleWorkingFF", "-speed=10000", "-number=100000", "-testScenario=1", "-inport1=0", "-outport1=0", "-inport2=1", "-testType=0"
                     ]
                 },
                 {
-                    "image-name": "nff-go-test-singleWorkingFF",
+                    "image-name": "nff-go-test-singleworkingff",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
                         "./testSingleWorkingFF", "-testScenario=2", "-inport1=0", "-outport1=0", "-outport2=1", "-testType=0"
@@ -102,14 +102,14 @@
             "test-type": "TestTypeScenario",
             "test-apps": [
                 {
-                    "image-name": "nff-go-test-singleWorkingFF",
+                    "image-name": "nff-go-test-singleworkingff",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
                         "./testSingleWorkingFF", "-speed=10000", "-number=100000", "-testScenario=1", "-inport1=0", "-outport1=0", "-inport2=1", "-testType=1"
                     ]
                 },
                 {
-                    "image-name": "nff-go-test-singleWorkingFF",
+                    "image-name": "nff-go-test-singleworkingff",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
                         "./testSingleWorkingFF", "-testScenario=2", "-inport1=0", "-outport1=0", "-outport2=1", "-testType=1"
@@ -123,14 +123,14 @@
             "test-type": "TestTypeScenario",
             "test-apps": [
                 {
-                    "image-name": "nff-go-test-singleWorkingFF",
+                    "image-name": "nff-go-test-singleworkingff",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
                         "./testSingleWorkingFF", "-speed=10000", "-number=100000", "-testScenario=1", "-inport1=0", "-outport1=0", "-inport2=1", "-testType=4"
                     ]
                 },
                 {
-                    "image-name": "nff-go-test-singleWorkingFF",
+                    "image-name": "nff-go-test-singleworkingff",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
                         "./testSingleWorkingFF", "-testScenario=2", "-inport1=0", "-outport1=0", "-outport2=1", "-testType=4"
@@ -144,14 +144,14 @@
             "test-type": "TestTypeScenario",
             "test-apps": [
                 {
-                    "image-name": "nff-go-test-singleWorkingFF",
+                    "image-name": "nff-go-test-singleworkingff",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
                         "./testSingleWorkingFF", "-speed=10000", "-number=100000", "-testScenario=1", "-inport1=0", "-outport1=0", "-inport2=1", "-testType=5"
                     ]
                 },
                 {
-                    "image-name": "nff-go-test-singleWorkingFF",
+                    "image-name": "nff-go-test-singleworkingff",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
                         "./testSingleWorkingFF", "-testScenario=2", "-inport1=0", "-outport1=0", "-outport2=1", "-testType=5"
@@ -165,14 +165,14 @@
             "test-type": "TestTypeScenario",
             "test-apps": [
                 {
-                    "image-name": "nff-go-test-singleWorkingFF",
+                    "image-name": "nff-go-test-singleworkingff",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
                         "./testSingleWorkingFF", "-speed=10000", "-number=100000", "-testScenario=1", "-inport1=0", "-outport1=0", "-inport2=1", "-testType=6"
                     ]
                 },
                 {
-                    "image-name": "nff-go-test-singleWorkingFF",
+                    "image-name": "nff-go-test-singleworkingff",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
                         "./testSingleWorkingFF", "-testScenario=2", "-inport1=0", "-outport1=0", "-outport2=1", "-testType=6"
@@ -186,14 +186,14 @@
             "test-type": "TestTypeScenario",
             "test-apps": [
                 {
-                    "image-name": "nff-go-test-singleWorkingFF",
+                    "image-name": "nff-go-test-singleworkingff",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
                         "./testSingleWorkingFF", "-speed=10000", "-number=100000", "-testScenario=1", "-inport1=1", "-outport1=0", "-testType=8"
                     ]
                 },
                 {
-                    "image-name": "nff-go-test-singleWorkingFF",
+                    "image-name": "nff-go-test-singleworkingff",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
                         "./testSingleWorkingFF", "-testScenario=2", "-inport1=0", "-outport1=1", "-testType=8"
@@ -207,14 +207,14 @@
             "test-type": "TestTypeScenario",
             "test-apps": [
                 {
-                    "image-name": "nff-go-test-singleWorkingFF",
+                    "image-name": "nff-go-test-singleworkingff",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
                         "./testSingleWorkingFF", "-speed=10000", "-number=100000", "-testScenario=1", "-inport1=1", "-outport1=0", "-testType=9"
                     ]
                 },
                 {
-                    "image-name": "nff-go-test-singleWorkingFF",
+                    "image-name": "nff-go-test-singleworkingff",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
                         "./testSingleWorkingFF", "-testScenario=2", "-inport1=0", "-outport1=1", "-testType=9"
@@ -228,14 +228,14 @@
             "test-type": "TestTypeScenario",
             "test-apps": [
                 {
-                    "image-name": "nff-go-test-singleWorkingFF",
+                    "image-name": "nff-go-test-singleworkingff",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
                         "./testSingleWorkingFF", "-speed=10000", "-number=100000", "-testScenario=1", "-inport1=1", "-outport1=0", "-testType=10"
                     ]
                 },
                 {
-                    "image-name": "nff-go-test-singleWorkingFF",
+                    "image-name": "nff-go-test-singleworkingff",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
                         "./testSingleWorkingFF", "-testScenario=2", "-inport1=0", "-outport1=1", "-testType=10"
@@ -249,14 +249,14 @@
             "test-type": "TestTypeScenario",
             "test-apps": [
                 {
-                    "image-name": "nff-go-test-singleWorkingFF",
+                    "image-name": "nff-go-test-singleworkingff",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
                         "./testSingleWorkingFF", "-speed=10000", "-number=100000", "-testScenario=1", "-inport1=1", "-outport1=0", "-testType=11"
                     ]
                 },
                 {
-                    "image-name": "nff-go-test-singleWorkingFF",
+                    "image-name": "nff-go-test-singleworkingff",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
                         "./testSingleWorkingFF", "-testScenario=2", "-inport1=0", "-outport1=1", "-testType=11"

--- a/test/stability/testCksum/testCksum.go
+++ b/test/stability/testCksum/testCksum.go
@@ -43,6 +43,7 @@ import (
 
 var (
 	totalPackets uint64 = 10
+	passedLimit  uint64 = 98
 
 	// Packet should hold at least two int64 fields
 	minPayloadSize        = int(unsafe.Sizeof(sentPackets) * 2)
@@ -307,7 +308,7 @@ func composeStatistics() error {
 	println("Sent", sent, "packets")
 	println("Received", received, "packets")
 	println("Ratio = ", ratio, "%")
-	if atomic.LoadInt32(&passed) != 0 && ratio >= 90 {
+	if atomic.LoadInt32(&passed) != 0 && ratio >= passedLimit {
 		println("TEST PASSED")
 		return nil
 	}

--- a/test/stability/testMerge/testMerge.go
+++ b/test/stability/testMerge/testMerge.go
@@ -39,7 +39,8 @@ var (
 	// Payload is 16 byte md5 hash sum of headers
 	payloadSize uint   = 16
 	speed       uint64 = 1000000
-	passedLimit uint64 = 85
+	passedLimit uint64 = 98
+	delta       int    = 2
 
 	sentPacketsGroup1 uint64
 	sentPacketsGroup2 uint64
@@ -227,7 +228,7 @@ func composeStatistics() error {
 	// Test is passed, if p1 and p2 do not differ too much: |p1-p2| < 4%
 	// and enough packets received back
 	if atomic.LoadInt32(&passed) != 0 &&
-		(p1-p2 < 4 && p1-p2 > -4) && received*100/sent > passedLimit {
+		(p1-p2 < delta && p1-p2 > -delta) && received*100/sent > passedLimit {
 		println("TEST PASSED")
 		return nil
 	}

--- a/test/stability/testSingleWorkingFF/Makefile
+++ b/test/stability/testSingleWorkingFF/Makefile
@@ -3,7 +3,7 @@
 # license that can be found in the LICENSE file.
 
 PATH_TO_MK = ../../../mk
-IMAGENAME = nff-go-test-singleWorkingFF
+IMAGENAME = nff-go-test-singleworkingff
 EXECUTABLES = testSingleWorkingFF
 
 all:

--- a/test/stability/testSingleWorkingFF/testSingleWorkingFF.go
+++ b/test/stability/testSingleWorkingFF/testSingleWorkingFF.go
@@ -92,8 +92,8 @@ var (
 	l3Rules     *packet.L3Rules
 	gTestType   uint
 	lessPercent int
-	eps         int
 	passedLimit uint64
+	delta       int = 2
 	checkSlice  []uint8
 	shift       uint64
 )
@@ -256,8 +256,7 @@ func executeTest(configFile, target string, testScenario uint, testType uint) er
 }
 
 func setParameters(testScenario uint) (err error) {
-	eps = 3
-	passedLimit = 85
+	passedLimit = 98
 	shift = 0
 	totalPackets = userTotalPackets
 	switch gTestType {
@@ -274,14 +273,13 @@ func setParameters(testScenario uint) (err error) {
 		}
 		// Test expects to receive 20% of packets on 0 port and 80% on 1 port
 		lessPercent = 20
-		eps = 4
 	case partition, vpartition:
 		// Test expects to receive 10% of packets on 0 port and 90% on 1 port
 		lessPercent = 10
 	case pcopy:
 		// Test expects to receive 50% of packets on 0 port and 50% on 1 port (200% total)
 		lessPercent = 50
-		passedLimit = 150 // ~85 * 2
+		passedLimit = 196 // ~98 * 2
 	case handle, vhandle:
 		// Test expects to receive 100% of packets on 0 port and 0% on 1 port
 		lessPercent = 100
@@ -292,7 +290,7 @@ func setParameters(testScenario uint) (err error) {
 		}
 		// Test expects to receive 100% of packets on 0 port and 0% on 1 port (33% total)
 		lessPercent = 100
-		passedLimit = 28 // 85 * 0.33
+		passedLimit = 31 // 98 * 0.33
 		totalPackets = totalPackets / 3
 		shift = 4
 	}
@@ -389,8 +387,8 @@ func composeStatistics() error {
 	// Test is passed, if p1 is ~lessPercent% and p2 is ~100 - lessPercent%
 	// and if total receive/send rate is high
 	if broken == 0 &&
-		p1 <= lessPercent+eps && p2 <= 100-lessPercent+eps &&
-		p1 >= lessPercent-eps && p2 >= 100-lessPercent-eps && received*100/sent > passedLimit {
+		p1 <= lessPercent+delta && p2 <= 100-lessPercent+delta &&
+		p1 >= lessPercent-delta && p2 >= 100-lessPercent-delta && received*100/sent > passedLimit {
 		println("TEST PASSED")
 		return nil
 	}


### PR DESCRIPTION
1) Fix problem with docker image name - it must have only low-case letters
2) Highly increase tests rates. Now test will pass only with 98% ratio and +-2% for dividi limits

This can be achieved after https://github.com/intel-go/nff-go/commit/9ef055cd1ba3f8ca77569e3a779ed95537014a50 fix.