### PR TITLE
Added variables to test framework and other improvements

### DIFF
--- a/test/framework/config.go
+++ b/test/framework/config.go
@@ -10,23 +10,11 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
 )
-
-type hostPort struct {
-	host string
-	port int
-}
-
-// HostsList is a slice of host:port pairs that are used to replace
-// values read from JSON config file.
-type HostsList []hostPort
-
-func (hl *HostsList) String() string {
-	return fmt.Sprint(*hl)
-}
 
 // BenchmarkConfig struct has settings controlling benchmark
 // parameters, usually for tests with type TestTypeBenchmark.
@@ -113,12 +101,14 @@ type DockerConfig struct {
 type TestsuiteConfig struct {
 	// Settings which control docker daemon functionality.
 	Config DockerConfig `json:"docker-config"`
+	// A set of variables for tests command lines
+	Variables map[string]string
 	// Array of test cases.
 	Tests []TestConfig `json:"tests"`
 }
 
 // ReadConfig function reads and parses config file.
-func ReadConfig(fileName string, hl HostsList) (*TestsuiteConfig, error) {
+func ReadConfig(fileName string, hl HostsList, vl VariablesList) (*TestsuiteConfig, error) {
 	var config TestsuiteConfig
 
 	file, err := os.Open(fileName)
@@ -145,7 +135,47 @@ func ReadConfig(fileName string, hl HostsList) (*TestsuiteConfig, error) {
 		}
 	}
 
+	// Merge variables from command line into default variable values
+	// from JSON configuration
+	for kkk, vvv := range vl {
+		config.Variables[kkk] = vvv
+	}
+
+	// Replace variables in test command lines
+	for ttt := range config.Tests {
+		for aaa := range config.Tests[ttt].Apps {
+			app := &config.Tests[ttt].Apps[aaa]
+			cmd := app.CommandLine
+
+			for kkk, vvv := range config.Variables {
+				for ccc := 0; ccc < len(cmd); {
+					newparam := strings.Replace(cmd[ccc], kkk, vvv, -1)
+					if newparam == "" {
+						cmd = append(cmd[:ccc], cmd[ccc+1:]...)
+					} else {
+						cmd[ccc] = newparam
+						ccc++
+					}
+				}
+			}
+			app.CommandLine = cmd
+		}
+	}
+
 	return &config, nil
+}
+
+type hostPort struct {
+	host string
+	port int
+}
+
+// HostsList is a slice of host:port pairs that are used to replace
+// values read from JSON config file.
+type HostsList []hostPort
+
+func (hl *HostsList) String() string {
+	return fmt.Sprint(*hl)
 }
 
 func (hl *HostsList) Set(value string) error {
@@ -168,5 +198,38 @@ func (hl *HostsList) Set(value string) error {
 			port: int(port),
 		})
 	}
+	return nil
+}
+
+// Variable is a string in a form of NAME=VALUE pair which is replaced
+// inside of tests command lines.
+type VariablesList map[string]string
+
+func (vl *VariablesList) String() string {
+	return fmt.Sprint(*vl)
+}
+
+func (vl *VariablesList) Set(value string) error {
+	parts := strings.SplitAfterN(value, "=", 2)
+	if len(parts) != 2 {
+		return errors.New("Bad variable format: " + value)
+	}
+
+	(*vl)[strings.TrimRight(parts[0], "=")] = parts[1]
+	return nil
+}
+
+type TestsList []*regexp.Regexp
+
+func (tl *TestsList) String() string {
+	return fmt.Sprint(*tl)
+}
+
+func (tl *TestsList) Set(value string) error {
+	r, err := regexp.Compile(value)
+	if err != nil {
+		return err
+	}
+	*tl = append(*tl, r)
 	return nil
 }

--- a/test/framework/main/stability.json
+++ b/test/framework/main/stability.json
@@ -11,6 +11,21 @@
         ],
         "pktgen-port": 22022
     },
+    "variables": {
+        "INPORT1_1": "0",
+        "INPORT1_2": "1",
+        "OUTPORT1_1": "1",
+        "OUTPORT1_2": "0",
+        "INPORT2_1": "1",
+        "INPORT2_2": "0",
+        "OUTPORT2_1": "0",
+        "OUTPORT2_2": "1",
+        "NUMBER": "1000000",
+        "SPEED": "1000000",
+        "TIMEOUT": "",
+        "VB_WORKAROUND": "",
+        "KVM_WORKAROUND": ""
+    },
     "tests": [
         {
             "name": "merge",
@@ -54,7 +69,7 @@
                 }
             ]
         },
-	{
+        {
             "name": "vector split",
             "test-time": 90000000000,
             "test-type": "TestTypeScenario",
@@ -96,7 +111,7 @@
                 }
             ]
         },
-	{
+        {
             "name": "vector separate",
             "test-time": 60000000000,
             "test-type": "TestTypeScenario",
@@ -138,7 +153,7 @@
                 }
             ]
         },
-	{
+        {
             "name": "vector partition",
             "test-time": 60000000000,
             "test-type": "TestTypeScenario",
@@ -159,7 +174,7 @@
                 }
             ]
         },
-	{
+        {
             "name": "pcopy",
             "test-time": 60000000000,
             "test-type": "TestTypeScenario",
@@ -201,7 +216,7 @@
                 }
             ]
         },
-	{
+        {
             "name": "vector handle",
             "test-time": 60000000000,
             "test-type": "TestTypeScenario",
@@ -222,7 +237,7 @@
                 }
             ]
         },
-	{
+        {
             "name": "dhandle",
             "test-time": 60000000000,
             "test-type": "TestTypeScenario",
@@ -243,7 +258,7 @@
                 }
             ]
         },
-	{
+        {
             "name": "vector dhandle",
             "test-time": 60000000000,
             "test-type": "TestTypeScenario",
@@ -273,14 +288,14 @@
                     "image-name": "nff-go-test-cksum",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
-                        "./testCksum", "-testScenario=1", "-hwol", "-ipv4", "-tcp", "-number=1000000", "-inport=0", "-outport=1", "-speed=1000000"
+                        "./testCksum", "-testScenario=1", "-hwol", "-ipv4", "-tcp", "-number=NUMBER", "-inport=INPORT1_1", "-outport=OUTPORT1_1", "-speed=SPEED", "TIMEOUT", "KVM_WORKAROUND"
                     ]
                 },
                 {
                     "image-name": "nff-go-test-cksum",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
-                        "./testCksum", "-testScenario=2", "-hwol", "-inport=1", "-outport=0"
+                        "./testCksum", "-testScenario=2", "-hwol", "-inport=INPORT2_1", "-outport=OUTPORT2_1"
                     ]
                 }
             ]
@@ -294,14 +309,14 @@
                     "image-name": "nff-go-test-cksum",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
-                        "./testCksum", "-testScenario=1", "-hwol", "-ipv4", "-udp", "-number=1000000", "-inport=0", "-outport=1", "-speed=1000000"
+                        "./testCksum", "-testScenario=1", "-hwol", "-ipv4", "-udp", "-number=NUMBER", "-inport=INPORT1_1", "-outport=OUTPORT1_1", "-speed=SPEED", "TIMEOUT", "VB_WORKAROUND"
                     ]
                 },
                 {
                     "image-name": "nff-go-test-cksum",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
-                        "./testCksum", "-testScenario=2", "-hwol", "-inport=1", "-outport=0"
+                        "./testCksum", "-testScenario=2", "-hwol", "-inport=INPORT2_1", "-outport=OUTPORT2_1"
                     ]
                 }
             ]
@@ -315,14 +330,14 @@
                     "image-name": "nff-go-test-cksum",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
-                        "./testCksum", "-testScenario=1", "-hwol", "-ipv4", "-icmp", "-number=1000000", "-inport=0", "-outport=1", "-speed=1000000"
+                        "./testCksum", "-testScenario=1", "-hwol", "-ipv4", "-icmp", "-number=NUMBER", "-inport=INPORT1_1", "-outport=OUTPORT1_1", "-speed=SPEED", "TIMEOUT"
                     ]
                 },
                 {
                     "image-name": "nff-go-test-cksum",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
-                        "./testCksum", "-testScenario=2", "-hwol", "-inport=1", "-outport=0"
+                        "./testCksum", "-testScenario=2", "-hwol", "-inport=INPORT2_1", "-outport=OUTPORT2_1"
                     ]
                 }
             ]
@@ -336,14 +351,14 @@
                     "image-name": "nff-go-test-cksum",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
-                        "./testCksum", "-testScenario=1", "-hwol", "-ipv6", "-tcp", "-number=1000000", "-inport=0", "-outport=1", "-speed=1000000"
+                        "./testCksum", "-testScenario=1", "-hwol", "-ipv6", "-tcp", "-number=NUMBER", "-inport=INPORT1_1", "-outport=OUTPORT1_1", "-speed=SPEED", "TIMEOUT", "KVM_WORKAROUND"
                     ]
                 },
                 {
                     "image-name": "nff-go-test-cksum",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
-                        "./testCksum", "-testScenario=2", "-hwol", "-inport=1", "-outport=0"
+                        "./testCksum", "-testScenario=2", "-hwol", "-inport=INPORT2_1", "-outport=OUTPORT2_1"
                     ]
                 }
             ]
@@ -357,14 +372,14 @@
                     "image-name": "nff-go-test-cksum",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
-                        "./testCksum", "-testScenario=1", "-hwol", "-ipv6", "-udp", "-number=1000000", "-inport=0", "-outport=1", "-speed=1000000"
+                        "./testCksum", "-testScenario=1", "-hwol", "-ipv6", "-udp", "-number=NUMBER", "-inport=INPORT1_1", "-outport=OUTPORT1_1", "-speed=SPEED", "TIMEOUT", "VB_WORKAROUND"
                     ]
                 },
                 {
                     "image-name": "nff-go-test-cksum",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
-                        "./testCksum", "-testScenario=2", "-hwol", "-inport=1", "-outport=0"
+                        "./testCksum", "-testScenario=2", "-hwol", "-inport=INPORT2_1", "-outport=OUTPORT2_1"
                     ]
                 }
             ]
@@ -378,14 +393,14 @@
                     "image-name": "nff-go-test-cksum",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
-                        "./testCksum", "-testScenario=1", "-ipv6", "-icmp", "-number=1000000", "-inport=0", "-outport=1", "-speed=1000000"
+                        "./testCksum", "-testScenario=1", "-ipv6", "-icmp", "-number=NUMBER", "-inport=INPORT1_1", "-outport=OUTPORT1_1", "-speed=SPEED", "TIMEOUT"
                     ]
                 },
                 {
                     "image-name": "nff-go-test-cksum",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
-                        "./testCksum", "-testScenario=2", "-hwol", "-inport=1", "-outport=0"
+                        "./testCksum", "-testScenario=2", "-hwol", "-inport=INPORT2_1", "-outport=OUTPORT2_1"
                     ]
                 }
             ]
@@ -399,14 +414,14 @@
                     "image-name": "nff-go-test-cksum",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
-                        "./testCksum", "-testScenario=1", "-hwol", "-ipv4", "-tcp", "-vlan", "-number=1000000", "-inport=0", "-outport=1", "-speed=1000000"
+                        "./testCksum", "-testScenario=1", "-hwol", "-ipv4", "-tcp", "-vlan", "-number=NUMBER", "-inport=INPORT1_1", "-outport=OUTPORT1_1", "-speed=SPEED", "TIMEOUT", "KVM_WORKAROUND"
                     ]
                 },
                 {
                     "image-name": "nff-go-test-cksum",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
-                        "./testCksum", "-testScenario=2", "-hwol", "-vlan", "-inport=1", "-outport=0"
+                        "./testCksum", "-testScenario=2", "-hwol", "-vlan", "-inport=INPORT2_1", "-outport=OUTPORT2_1"
                     ]
                 }
             ]
@@ -420,14 +435,14 @@
                     "image-name": "nff-go-test-cksum",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
-                        "./testCksum", "-testScenario=1", "-hwol", "-ipv4", "-udp", "-vlan", "-number=1000000", "-inport=0", "-outport=1", "-speed=1000000"
+                        "./testCksum", "-testScenario=1", "-hwol", "-ipv4", "-udp", "-vlan", "-number=NUMBER", "-inport=INPORT1_1", "-outport=OUTPORT1_1", "-speed=SPEED", "TIMEOUT", "VB_WORKAROUND"
                     ]
                 },
                 {
                     "image-name": "nff-go-test-cksum",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
-                        "./testCksum", "-testScenario=2", "-hwol", "-vlan", "-inport=1", "-outport=0"
+                        "./testCksum", "-testScenario=2", "-hwol", "-vlan", "-inport=INPORT2_1", "-outport=OUTPORT2_1"
                     ]
                 }
             ]
@@ -441,14 +456,14 @@
                     "image-name": "nff-go-test-cksum",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
-                        "./testCksum", "-testScenario=1", "-hwol", "-ipv4", "-icmp", "-vlan",  "-number=1000000", "-inport=0", "-outport=1", "-speed=1000000"
+                        "./testCksum", "-testScenario=1", "-hwol", "-ipv4", "-icmp", "-vlan",  "-number=NUMBER", "-inport=INPORT1_1", "-outport=OUTPORT1_1", "-speed=SPEED", "TIMEOUT"
                     ]
                 },
                 {
                     "image-name": "nff-go-test-cksum",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
-                        "./testCksum", "-testScenario=2", "-hwol", "-vlan", "-inport=1", "-outport=0"
+                        "./testCksum", "-testScenario=2", "-hwol", "-vlan", "-inport=INPORT2_1", "-outport=OUTPORT2_1"
                     ]
                 }
             ]
@@ -462,14 +477,14 @@
                     "image-name": "nff-go-test-cksum",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
-                        "./testCksum", "-testScenario=1", "-hwol", "-ipv6", "-tcp", "-vlan", "-number=1000000", "-inport=0", "-outport=1", "-speed=1000000"
+                        "./testCksum", "-testScenario=1", "-hwol", "-ipv6", "-tcp", "-vlan", "-number=NUMBER", "-inport=INPORT1_1", "-outport=OUTPORT1_1", "-speed=SPEED", "TIMEOUT", "KVM_WORKAROUND"
                     ]
                 },
                 {
                     "image-name": "nff-go-test-cksum",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
-                        "./testCksum", "-testScenario=2", "-hwol", "-vlan", "-inport=1", "-outport=0"
+                        "./testCksum", "-testScenario=2", "-hwol", "-vlan", "-inport=INPORT2_1", "-outport=OUTPORT2_1"
                     ]
                 }
             ]
@@ -483,14 +498,14 @@
                     "image-name": "nff-go-test-cksum",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
-                        "./testCksum", "-testScenario=1", "-hwol", "-ipv6", "-udp", "-vlan", "-number=1000000", "-inport=0", "-outport=1", "-speed=1000000"
+                        "./testCksum", "-testScenario=1", "-hwol", "-ipv6", "-udp", "-vlan", "-number=NUMBER", "-inport=INPORT1_1", "-outport=OUTPORT1_1", "-speed=SPEED", "TIMEOUT", "VB_WORKAROUND"
                     ]
                 },
                 {
                     "image-name": "nff-go-test-cksum",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
-                        "./testCksum", "-testScenario=2", "-hwol", "-vlan", "-inport=1", "-outport=0"
+                        "./testCksum", "-testScenario=2", "-hwol", "-vlan", "-inport=INPORT2_1", "-outport=OUTPORT2_1"
                     ]
                 }
             ]
@@ -504,14 +519,14 @@
                     "image-name": "nff-go-test-cksum",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
-                        "./testCksum", "-testScenario=1", "-ipv6", "-icmp", "-vlan",  "-number=1000000", "-inport=0", "-outport=1", "-speed=1000000"
+                        "./testCksum", "-testScenario=1", "-ipv6", "-icmp", "-vlan",  "-number=NUMBER", "-inport=INPORT1_1", "-outport=OUTPORT1_1", "-speed=SPEED", "TIMEOUT"
                     ]
                 },
                 {
                     "image-name": "nff-go-test-cksum",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
-                        "./testCksum", "-testScenario=2", "-hwol", "-vlan", "-inport=1", "-outport=0"
+                        "./testCksum", "-testScenario=2", "-hwol", "-vlan", "-inport=INPORT2_1", "-outport=OUTPORT2_1"
                     ]
                 }
             ]

--- a/test/framework/main/tf.go
+++ b/test/framework/main/tf.go
@@ -13,6 +13,8 @@ import (
 )
 
 var hl test.HostsList
+var vl test.VariablesList = test.VariablesList{}
+var tl test.TestsList
 
 func main() {
 	test.SetLogLevel(test.LogDebugLvl)
@@ -20,13 +22,15 @@ func main() {
 	var directory string
 
 	flag.Var(&hl, "hosts", "Comma-separated list of `host:port,host:port...host:port` pairs to override settings in config file, e.g. \"-hosts host1:2375,host2:2376\".")
+	flag.Var(&vl, "var", "Variables listed in form NAME=VALUE. Variables are replaced in tests command lines in form NAME substring is replaced with VALUE. If whole paramenters becomes an empty string it is deleted entirely from command line. Multiple -var flags are allowed. Command line replacement order is not defined.")
+	flag.Var(&tl, "test", "Testcase regexp to execute. Test is executed if regexp matches test name substring. Multiple -test flags are allowed. If no -test flag is specified, all testcases in config file are executed.")
 	flag.StringVar(&configFile, "config", "config.json", "Name of config file to use")
 	flag.StringVar(&directory, "directory", "", "Use `directory` to output log files instead of timestamp")
 	flag.BoolVar(&test.NoDeleteContainersOnExit, "nodelete", false, "Do not remove containers after tests finish")
 	flag.Parse()
 
 	// Read config
-	config, err := test.ReadConfig(configFile, hl)
+	config, err := test.ReadConfig(configFile, hl, vl)
 	if err != nil {
 		test.LogPanic(err)
 	}
@@ -41,6 +45,6 @@ func main() {
 	}
 
 	// Start test execution
-	status := config.RunAllTests(directory)
+	status := config.RunAllTests(directory, tl)
 	os.Exit(status)
 }


### PR DESCRIPTION
Variables allow arbitrary string replacement in tests command
lines. New section of test configuration now defines default variable
values, other variables with values may be added or overridden from
command line.

Added -test switch to allow selecting only one/several tests from
configuration file.

Improved pass/fail diagnostics.

The first experimental step of converting configuration files is done
on stability.json checksum tests.