### PR TITLE
Fixed VM system network configuration to have special name

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -75,6 +75,9 @@ sudo systemctl start network-manager
 SHELL
 
 $provision_common = <<SHELL
+echo Reassigning \'Wired connection 1\' interface to system name
+sudo nmcli c mod 'Wired connection 1' connection.id 'System connection'
+
 echo Unpacking Go language into /opt
 (cd /opt; sudo sh -c 'curl -L -s https://dl.google.com/go/go1.10.1.linux-amd64.tar.gz | tar zx')
 mkdir go

--- a/vagrant/scripts.sh
+++ b/vagrant/scripts.sh
@@ -1,3 +1,4 @@
+export DPDK_VERSION=18.02
 export GOPATH="$HOME"/go
 export GOROOT=/opt/go
 export NFF_GO="$GOPATH"/src/github.com/intel-go/nff-go
@@ -12,14 +13,14 @@ export CARD2=ens7
 bindports ()
 {
     sudo modprobe uio
-    sudo insmod "$NFF_GO"/dpdk/dpdk-18.02/x86_64-native-linuxapp-gcc/kmod/igb_uio.ko
-    sudo "$NFF_GO"/dpdk/dpdk-18.02/usertools/dpdk-devbind.py --bind=igb_uio $NFF_GO_CARDS
+    sudo insmod "$NFF_GO"/dpdk/dpdk-${DPDK_VERSION}/x86_64-native-linuxapp-gcc/kmod/igb_uio.ko
+    sudo "$NFF_GO"/dpdk/dpdk-${DPDK_VERSION}/usertools/dpdk-devbind.py --bind=igb_uio $NFF_GO_CARDS
 }
 
 # Bind ports to Linux kernel driver
 unbindports ()
 {
-    sudo "$NFF_GO"/dpdk/dpdk-18.02/usertools/dpdk-devbind.py --bind=e1000 $NFF_GO_CARDS
+    sudo "$NFF_GO"/dpdk/dpdk-${DPDK_VERSION}/usertools/dpdk-devbind.py --bind=e1000 $NFF_GO_CARDS
 }
 
 # Run pktgen


### PR DESCRIPTION
This is necessary for testing scripts to work correctly because
generic name connections are wiped as garbage.
Fix for #356.