### PR TITLE
Fixed a bug 'index out of range' when port is more than 1 in testSingleFF

### DIFF
--- a/test/stability/testSingleWorkingFF/testSingleWorkingFF.go
+++ b/test/stability/testSingleWorkingFF/testSingleWorkingFF.go
@@ -153,9 +153,9 @@ func executeTest(configFile, target string, testScenario uint, testType uint) er
 	checkSlice = make([]uint8, userTotalPackets*2, userTotalPackets*2)
 
 	stabilityCommon.InitCommonState(configFile, target)
-	fixMACAddrs = stabilityCommon.ModifyPacket[outport1].(func(*packet.Packet, flow.UserContext))
-	fixMACAddrs1 = stabilityCommon.ModifyPacket[outport1].(func(*packet.Packet, flow.UserContext))
-	fixMACAddrs2 = stabilityCommon.ModifyPacket[outport2].(func(*packet.Packet, flow.UserContext))
+	fixMACAddrs = stabilityCommon.ModifyPacket[0].(func(*packet.Packet, flow.UserContext))
+	fixMACAddrs1 = stabilityCommon.ModifyPacket[0].(func(*packet.Packet, flow.UserContext))
+	fixMACAddrs2 = stabilityCommon.ModifyPacket[1].(func(*packet.Packet, flow.UserContext))
 
 	if err := setParameters(testScenario); err != nil {
 		return err


### PR DESCRIPTION
was 
2018/05/18 10:14:07 1 No config file specified, stub destination MAC addresses will be used
2018/05/18 10:14:07 1 panic: runtime error: index out of range
2018/05/18 10:14:07 1
2018/05/18 10:14:07 1 goroutine 1 [running]:
2018/05/18 10:14:07 1 main.executeTest(0x0, 0x0, 0x0, 0x0, 0x2, 0x2, 0x28, 0x0)
2018/05/18 10:14:07 1   /localdisk/src/github.com/intel-go/nff-go/test/stability/testSingleWorkingFF/testSingleWorkingFF.go:158 +0xb85
2018/05/18 10:14:07 1 main.main()
2018/05/18 10:14:07 1   /localdisk/src/github.com/intel-go/nff-go/test/stability/testSingleWorkingFF/testSingleWorkingFF.go:125 +0x45f 