### PR TITLE
Fix for #290. Work correctly if HW offloading is absent

### DIFF
--- a/examples/nat/config.go
+++ b/examples/nat/config.go
@@ -279,3 +279,14 @@ func InitFlows() {
 		dropsync = make([]sync.Mutex, asize)
 	}
 }
+
+func CheckHWOffloading() bool {
+	ports := []uint16{}
+
+	for i := range Natconfig.PortPairs {
+		pp := &Natconfig.PortPairs[i]
+		ports = append(ports, pp.PublicPort.Index, pp.PrivatePort.Index)
+	}
+
+	return flow.CheckHWCapability(flow.HWTXChecksumCapability, ports)
+}

--- a/examples/nat/main/nat.go
+++ b/examples/nat/main/nat.go
@@ -41,6 +41,13 @@ func main() {
 
 	flow.CheckFatal(flow.SystemInit(&nffgoconfig))
 
+	offloadingAvailable := nat.CheckHWOffloading()
+	if !nat.NoHWTXChecksum && !offloadingAvailable {
+		println("Warning! Requested hardware offloading is not available on all ports. Falling back to software checksum calculation.")
+		nat.NoHWTXChecksum = true
+		flow.SetUseHWCapability(flow.HWTXChecksumCapability, false)
+	}
+
 	// Initialize flows and necessary state
 	nat.InitFlows()
 

--- a/flow/flow.go
+++ b/flow/flow.go
@@ -319,6 +319,35 @@ func addSegment(in *low.Ring, first *Func) *processSegment {
 	return segment
 }
 
+type HWCapability int
+
+const (
+	HWTXChecksumCapability HWCapability = iota
+)
+
+// CheckHWCapability return true if hardware offloading capability
+// present in all ports. Otherwise it returns false.
+func CheckHWCapability(capa HWCapability, ports []uint16) bool {
+	for p := range ports {
+		switch capa {
+		case HWTXChecksumCapability:
+			if !low.CheckHWTXChecksumCapability(ports[p]) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// SetUseHWCapability enables or disables using a hardware offloading
+// capability.
+func SetUseHWCapability(capa HWCapability, use bool) {
+	switch capa {
+	case HWTXChecksumCapability:
+		packet.SetHWTXChecksumFlag(use)
+	}
+}
+
 const burstSize = 32
 const reportMbits = false
 

--- a/low/low.go
+++ b/low/low.go
@@ -56,8 +56,9 @@ var mbufCacheSizeT uint
 
 type mempoolPair struct {
 	mempool *C.struct_rte_mempool
-	name string
+	name    string
 }
+
 var usedMempools []mempoolPair
 
 func GetPort(n uint16) *Port {
@@ -524,13 +525,13 @@ func CreatePort(port uint16, willReceive bool, sendQueuesNumber uint16, promiscu
 // CreateMempool creates and returns a new memory pool.
 func CreateMempool(name string) *Mempool {
 	nameC := 1
-        tName := name
-        for i := range usedMempools {
-                if usedMempools[i].name == tName {
-                        tName = name + strconv.Itoa(nameC)
-                        nameC++
-                }
-        }
+	tName := name
+	for i := range usedMempools {
+		if usedMempools[i].name == tName {
+			tName = name + strconv.Itoa(nameC)
+			nameC++
+		}
+	}
 	mempool := C.createMempool(C.uint32_t(mbufNumberT), C.uint32_t(mbufCacheSizeT))
 	usedMempools = append(usedMempools, mempoolPair{mempool, tName})
 	return (*Mempool)(mempool)
@@ -650,4 +651,8 @@ func BoolToInt(value bool) uint8 {
 
 func IntArrayToBool(value *[32]uint8) *[32]bool {
 	return (*[32]bool)(unsafe.Pointer(value))
+}
+
+func CheckHWTXChecksumCapability(port uint16) bool {
+	return bool(C.check_hwtxchecksum_capability(C.uint16_t(port)))
 }

--- a/low/low.h
+++ b/low/low.h
@@ -615,3 +615,17 @@ static int KNI_config_promiscusity(uint16_t port_id, uint8_t to_on) {
 	fprintf(stderr, "DEBUG: KNI: Promiscusity mode of port %d %s\n", port_id, to_on ? "on" : "off");
 	return 0;
 }
+
+bool check_hwtxchecksum_capability(uint16_t port_id) {
+	uint64_t flags = DEV_TX_OFFLOAD_IPV4_CKSUM |
+		DEV_TX_OFFLOAD_UDP_CKSUM |
+		DEV_TX_OFFLOAD_TCP_CKSUM;
+	struct rte_eth_dev_info dev_info;
+
+	if (port_id >= rte_eth_dev_count())
+		return false;
+
+	memset(&dev_info, 0, sizeof(dev_info));
+	rte_eth_dev_info_get(port_id, &dev_info);
+	return (dev_info.tx_offload_capa & flags) == flags;
+}

--- a/test/stability/testCksum/testCksum.go
+++ b/test/stability/testCksum/testCksum.go
@@ -121,6 +121,15 @@ func configTest(shouldUseIPv4, shouldUseIPv6, shouldUseUDP, shouldUseTCP, should
 	useTCP = shouldUseTCP
 	useUDP = shouldUseUDP
 	useVLAN = shouldUseVLAN
+
+	ports := []uint16{uint16(inport), uint16(outport)}
+	offloadingAvailable := flow.CheckHWCapability(flow.HWTXChecksumCapability, ports)
+	if hwol && !offloadingAvailable {
+		println("Warning! Requested hardware offloading is not available on all ports. Falling back to software checksum calculation.")
+		hwol = false
+		flow.SetUseHWCapability(flow.HWTXChecksumCapability, false)
+	}
+
 	if hwol {
 		print("hardware cksums and ")
 	}


### PR DESCRIPTION
Applications now have a way to determine HW offloading capabilities
and control their use by NFF-Go framework.