### PR TITLE
Added core limitations to performance tests

### DIFF
--- a/test/framework/main/latency.json
+++ b/test/framework/main/latency.json
@@ -24,7 +24,8 @@
     "SPEED1": "1000000",
     "SPEED2": "700000",
     "TIMEOUT_SCHED_OFF": "4s",
-    "TIMEOUT_SCHED_ON": "8s"
+    "TIMEOUT_SCHED_ON": "8s",
+    "CORES": "0-43"
   },
   "tests": [
     {
@@ -64,7 +65,7 @@
           "image-name": "nff-go-performance",
           "app-type": "TestAppGo",
           "exec-cmd": [
-            "./perf_light", "-mode=0", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2"
+            "./perf_light", "-mode=0", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2", "-cores=CORES"
           ]
         }
       ]
@@ -106,7 +107,7 @@
           "image-name": "nff-go-performance",
           "app-type": "TestAppGo",
           "exec-cmd": [
-            "./perf_light", "-mode=0", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2"
+            "./perf_light", "-mode=0", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2", "-cores=CORES"
           ]
         }
       ]
@@ -148,7 +149,7 @@
           "image-name": "nff-go-performance",
           "app-type": "TestAppGo",
           "exec-cmd": [
-            "./perf_light", "-mode=0", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2"
+            "./perf_light", "-mode=0", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2", "-cores=CORES"
           ]
         }
       ]
@@ -190,7 +191,7 @@
           "image-name": "nff-go-performance",
           "app-type": "TestAppGo",
           "exec-cmd": [
-            "./perf_light", "-mode=1", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2"
+            "./perf_light", "-mode=1", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2", "-cores=CORES"
           ]
         }
       ]
@@ -232,7 +233,7 @@
           "image-name": "nff-go-performance",
           "app-type": "TestAppGo",
           "exec-cmd": [
-            "./perf_light", "-mode=1", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2"
+            "./perf_light", "-mode=1", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2", "-cores=CORES"
           ]
         }
       ]
@@ -274,7 +275,7 @@
           "image-name": "nff-go-performance",
           "app-type": "TestAppGo",
           "exec-cmd": [
-            "./perf_light", "-mode=1", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2"
+            "./perf_light", "-mode=1", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2", "-cores=CORES"
           ]
         }
       ]
@@ -316,7 +317,7 @@
           "image-name": "nff-go-performance",
           "app-type": "TestAppGo",
           "exec-cmd": [
-            "./perf_light", "-mode=2", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2"
+            "./perf_light", "-mode=2", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2", "-cores=CORES"
           ]
         }
       ]
@@ -358,7 +359,7 @@
           "image-name": "nff-go-performance",
           "app-type": "TestAppGo",
           "exec-cmd": [
-            "./perf_light", "-mode=2", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2"
+            "./perf_light", "-mode=2", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2", "-cores=CORES"
           ]
         }
       ]
@@ -400,7 +401,7 @@
           "image-name": "nff-go-performance",
           "app-type": "TestAppGo",
           "exec-cmd": [
-            "./perf_light", "-mode=2", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2"
+            "./perf_light", "-mode=2", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2", "-cores=CORES"
           ]
         }
       ]
@@ -442,7 +443,7 @@
           "image-name": "nff-go-performance",
           "app-type": "TestAppGo",
           "exec-cmd": [
-            "./perf_main", "-load=1000", "-loadRW=50", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2"
+            "./perf_main", "-load=1000", "-loadRW=50", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2", "-cores=CORES"
           ]
         }
       ]
@@ -484,7 +485,7 @@
           "image-name": "nff-go-performance",
           "app-type": "TestAppGo",
           "exec-cmd": [
-            "./perf_main", "-load=1000", "-loadRW=50", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2"
+            "./perf_main", "-load=1000", "-loadRW=50", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2", "-cores=CORES"
           ]
         }
       ]
@@ -526,7 +527,7 @@
           "image-name": "nff-go-performance",
           "app-type": "TestAppGo",
           "exec-cmd": [
-            "./perf_main", "-load=1000", "-loadRW=50", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2"
+            "./perf_main", "-load=1000", "-loadRW=50", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2", "-cores=CORES"
           ]
         }
       ]
@@ -568,7 +569,7 @@
           "image-name": "nff-go-performance",
           "app-type": "TestAppGo",
           "exec-cmd": [
-            "./perf_main", "-load=1000", "-loadRW=50", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2"
+            "./perf_main", "-load=1000", "-loadRW=50", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2", "-cores=CORES"
           ]
         }
       ]
@@ -610,7 +611,7 @@
           "image-name": "nff-go-performance",
           "app-type": "TestAppGo",
           "exec-cmd": [
-            "./perf_main", "-load=1000", "-loadRW=0", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2"
+            "./perf_main", "-load=1000", "-loadRW=0", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2", "-cores=CORES"
           ]
         }
       ]
@@ -652,7 +653,7 @@
           "image-name": "nff-go-performance",
           "app-type": "TestAppGo",
           "exec-cmd": [
-            "./perf_main", "-load=1000", "-loadRW=0", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2"
+            "./perf_main", "-load=1000", "-loadRW=0", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2", "-cores=CORES"
           ]
         }
       ]
@@ -694,7 +695,7 @@
           "image-name": "nff-go-performance",
           "app-type": "TestAppGo",
           "exec-cmd": [
-            "./perf_main", "-load=1000", "-loadRW=0", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2"
+            "./perf_main", "-load=1000", "-loadRW=0", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2", "-cores=CORES"
           ]
         }
       ]
@@ -736,7 +737,7 @@
           "image-name": "nff-go-performance",
           "app-type": "TestAppGo",
           "exec-cmd": [
-            "./perf_main", "-load=1000", "-loadRW=0", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2"
+            "./perf_main", "-load=1000", "-loadRW=0", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2", "-cores=CORES"
           ]
         }
       ]
@@ -778,7 +779,7 @@
           "image-name": "nff-go-performance",
           "app-type": "TestAppGo",
           "exec-cmd": [
-            "./perf_main", "-load=500", "-loadRW=0", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2"
+            "./perf_main", "-load=500", "-loadRW=0", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2", "-cores=CORES"
           ]
         }
       ]
@@ -820,7 +821,7 @@
           "image-name": "nff-go-performance",
           "app-type": "TestAppGo",
           "exec-cmd": [
-            "./perf_main", "-load=500", "-loadRW=0", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2"
+            "./perf_main", "-load=500", "-loadRW=0", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2", "-cores=CORES"
           ]
         }
       ]
@@ -862,7 +863,7 @@
           "image-name": "nff-go-performance",
           "app-type": "TestAppGo",
           "exec-cmd": [
-            "./perf_main", "-load=500", "-loadRW=0", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2"
+            "./perf_main", "-load=500", "-loadRW=0", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2", "-cores=CORES"
           ]
         }
       ]
@@ -904,7 +905,7 @@
           "image-name": "nff-go-performance",
           "app-type": "TestAppGo",
           "exec-cmd": [
-            "./perf_main", "-load=500", "-loadRW=0", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2"
+            "./perf_main", "-load=500", "-loadRW=0", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2", "-cores=CORES"
           ]
         }
       ]
@@ -946,7 +947,7 @@
           "image-name": "nff-go-performance",
           "app-type": "TestAppGo",
           "exec-cmd": [
-            "./perf_main", "-load=250", "-loadRW=0", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2"
+            "./perf_main", "-load=250", "-loadRW=0", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2", "-cores=CORES"
           ]
         }
       ]
@@ -988,7 +989,7 @@
           "image-name": "nff-go-performance",
           "app-type": "TestAppGo",
           "exec-cmd": [
-            "./perf_main", "-load=250", "-loadRW=0", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2"
+            "./perf_main", "-load=250", "-loadRW=0", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2", "-cores=CORES"
           ]
         }
       ]
@@ -1030,7 +1031,7 @@
           "image-name": "nff-go-performance",
           "app-type": "TestAppGo",
           "exec-cmd": [
-            "./perf_main", "-load=250", "-loadRW=0", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2"
+            "./perf_main", "-load=250", "-loadRW=0", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2", "-cores=CORES"
           ]
         }
       ]
@@ -1072,7 +1073,7 @@
           "image-name": "nff-go-performance",
           "app-type": "TestAppGo",
           "exec-cmd": [
-            "./perf_main", "-load=250", "-loadRW=0", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2"
+            "./perf_main", "-load=250", "-loadRW=0", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2", "-cores=CORES"
           ]
         }
       ]
@@ -1114,7 +1115,7 @@
           "image-name": "nff-go-performance",
           "app-type": "TestAppGo",
           "exec-cmd": [
-            "./perf_seq", "-load=250", "-mode=2", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2"
+            "./perf_seq", "-load=250", "-mode=2", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2", "-cores=CORES"
           ]
         }
       ]
@@ -1156,7 +1157,7 @@
           "image-name": "nff-go-performance",
           "app-type": "TestAppGo",
           "exec-cmd": [
-            "./perf_seq", "-load=250", "-mode=2", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2"
+            "./perf_seq", "-load=250", "-mode=2", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2", "-cores=CORES"
           ]
         }
       ]
@@ -1198,7 +1199,7 @@
           "image-name": "nff-go-performance",
           "app-type": "TestAppGo",
           "exec-cmd": [
-            "./perf_seq", "-load=250", "-mode=2", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2"
+            "./perf_seq", "-load=250", "-mode=2", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2", "-cores=CORES"
           ]
         }
       ]
@@ -1240,7 +1241,7 @@
           "image-name": "nff-go-performance",
           "app-type": "TestAppGo",
           "exec-cmd": [
-            "./perf_seq", "-load=250", "-mode=2", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2"
+            "./perf_seq", "-load=250", "-mode=2", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2", "-cores=CORES"
           ]
         }
       ]
@@ -1282,7 +1283,7 @@
           "image-name": "nff-go-performance",
           "app-type": "TestAppGo",
           "exec-cmd": [
-            "./perf_seq", "-load=50", "-mode=2", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2"
+            "./perf_seq", "-load=50", "-mode=2", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2", "-cores=CORES"
           ]
         }
       ]
@@ -1324,7 +1325,7 @@
           "image-name": "nff-go-performance",
           "app-type": "TestAppGo",
           "exec-cmd": [
-            "./perf_seq", "-load=50", "-mode=2", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2"
+            "./perf_seq", "-load=50", "-mode=2", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2", "-cores=CORES"
           ]
         }
       ]
@@ -1366,7 +1367,7 @@
           "image-name": "nff-go-performance",
           "app-type": "TestAppGo",
           "exec-cmd": [
-            "./perf_seq", "-load=50", "-mode=2", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2"
+            "./perf_seq", "-load=50", "-mode=2", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2", "-cores=CORES"
           ]
         }
       ]
@@ -1408,7 +1409,7 @@
           "image-name": "nff-go-performance",
           "app-type": "TestAppGo",
           "exec-cmd": [
-            "./perf_seq", "-load=50", "-mode=2", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2"
+            "./perf_seq", "-load=50", "-mode=2", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2", "-cores=CORES"
           ]
         }
       ]
@@ -1450,7 +1451,7 @@
           "image-name": "nff-go-performance",
           "app-type": "TestAppGo",
           "exec-cmd": [
-            "./perf_seq", "-load=50", "-mode=3", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2"
+            "./perf_seq", "-load=50", "-mode=3", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2", "-cores=CORES"
           ]
         }
       ]
@@ -1492,7 +1493,7 @@
           "image-name": "nff-go-performance",
           "app-type": "TestAppGo",
           "exec-cmd": [
-            "./perf_seq", "-load=50", "-mode=3", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2"
+            "./perf_seq", "-load=50", "-mode=3", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2", "-cores=CORES"
           ]
         }
       ]
@@ -1534,7 +1535,7 @@
           "image-name": "nff-go-performance",
           "app-type": "TestAppGo",
           "exec-cmd": [
-            "./perf_seq", "-load=50", "-mode=3", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2"
+            "./perf_seq", "-load=50", "-mode=3", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2", "-cores=CORES"
           ]
         }
       ]
@@ -1576,7 +1577,7 @@
           "image-name": "nff-go-performance",
           "app-type": "TestAppGo",
           "exec-cmd": [
-            "./perf_seq", "-load=50", "-mode=3", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2"
+            "./perf_seq", "-load=50", "-mode=3", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2", "-cores=CORES"
           ]
         }
       ]
@@ -1618,7 +1619,7 @@
           "image-name": "nff-go-performance",
           "app-type": "TestAppGo",
           "exec-cmd": [
-            "./perf_seq", "-load=25", "-mode=3", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2"
+            "./perf_seq", "-load=25", "-mode=3", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2", "-cores=CORES"
           ]
         }
       ]
@@ -1660,7 +1661,7 @@
           "image-name": "nff-go-performance",
           "app-type": "TestAppGo",
           "exec-cmd": [
-            "./perf_seq", "-load=25", "-mode=3", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2"
+            "./perf_seq", "-load=25", "-mode=3", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2", "-cores=CORES"
           ]
         }
       ]
@@ -1702,7 +1703,7 @@
           "image-name": "nff-go-performance",
           "app-type": "TestAppGo",
           "exec-cmd": [
-            "./perf_seq", "-load=25", "-mode=3", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2"
+            "./perf_seq", "-load=25", "-mode=3", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2", "-cores=CORES"
           ]
         }
       ]
@@ -1744,7 +1745,7 @@
           "image-name": "nff-go-performance",
           "app-type": "TestAppGo",
           "exec-cmd": [
-            "./perf_seq", "-load=25", "-mode=3", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2"
+            "./perf_seq", "-load=25", "-mode=3", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2", "-cores=CORES"
           ]
         }
       ]
@@ -1786,7 +1787,7 @@
           "image-name": "nff-go-performance",
           "app-type": "TestAppGo",
           "exec-cmd": [
-            "./perf_seq", "-load=25", "-mode=13", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2"
+            "./perf_seq", "-load=25", "-mode=13", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2", "-cores=CORES"
           ]
         }
       ]
@@ -1828,7 +1829,7 @@
           "image-name": "nff-go-performance",
           "app-type": "TestAppGo",
           "exec-cmd": [
-            "./perf_seq", "-load=25", "-mode=13", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2"
+            "./perf_seq", "-load=25", "-mode=13", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2", "-cores=CORES"
           ]
         }
       ]
@@ -1870,7 +1871,7 @@
           "image-name": "nff-go-performance",
           "app-type": "TestAppGo",
           "exec-cmd": [
-            "./perf_seq", "-load=25", "-mode=13", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2"
+            "./perf_seq", "-load=25", "-mode=13", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2", "-cores=CORES"
           ]
         }
       ]
@@ -1912,7 +1913,7 @@
           "image-name": "nff-go-performance",
           "app-type": "TestAppGo",
           "exec-cmd": [
-            "./perf_seq", "-load=25", "-mode=13", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2"
+            "./perf_seq", "-load=25", "-mode=13", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2", "-cores=CORES"
           ]
         }
       ]
@@ -1954,7 +1955,7 @@
           "image-name": "nff-go-performance",
           "app-type": "TestAppGo",
           "exec-cmd": [
-            "./perf_seq", "-load=25", "-mode=4", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2"
+            "./perf_seq", "-load=25", "-mode=4", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2", "-cores=CORES"
           ]
         }
       ]
@@ -1996,7 +1997,7 @@
           "image-name": "nff-go-performance",
           "app-type": "TestAppGo",
           "exec-cmd": [
-            "./perf_seq", "-load=25", "-mode=4", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2"
+            "./perf_seq", "-load=25", "-mode=4", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2", "-cores=CORES"
           ]
         }
       ]
@@ -2038,7 +2039,7 @@
           "image-name": "nff-go-performance",
           "app-type": "TestAppGo",
           "exec-cmd": [
-            "./perf_seq", "-load=25", "-mode=4", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2"
+            "./perf_seq", "-load=25", "-mode=4", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2", "-cores=CORES"
           ]
         }
       ]
@@ -2080,7 +2081,7 @@
           "image-name": "nff-go-performance",
           "app-type": "TestAppGo",
           "exec-cmd": [
-            "./perf_seq", "-load=25", "-mode=4", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2"
+            "./perf_seq", "-load=25", "-mode=4", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2", "-cores=CORES"
           ]
         }
       ]
@@ -2122,7 +2123,7 @@
           "image-name": "nff-go-performance",
           "app-type": "TestAppGo",
           "exec-cmd": [
-            "./perf_seq", "-load=25", "-mode=14", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2"
+            "./perf_seq", "-load=25", "-mode=14", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2", "-cores=CORES"
           ]
         }
       ]
@@ -2164,7 +2165,7 @@
           "image-name": "nff-go-performance",
           "app-type": "TestAppGo",
           "exec-cmd": [
-            "./perf_seq", "-load=25", "-mode=14", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2"
+            "./perf_seq", "-load=25", "-mode=14", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2", "-cores=CORES"
           ]
         }
       ]
@@ -2206,7 +2207,7 @@
           "image-name": "nff-go-performance",
           "app-type": "TestAppGo",
           "exec-cmd": [
-            "./perf_seq", "-load=25", "-mode=14", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2"
+            "./perf_seq", "-load=25", "-mode=14", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2", "-cores=CORES"
           ]
         }
       ]
@@ -2248,7 +2249,7 @@
           "image-name": "nff-go-performance",
           "app-type": "TestAppGo",
           "exec-cmd": [
-            "./perf_seq", "-load=25", "-mode=14", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2"
+            "./perf_seq", "-load=25", "-mode=14", "-inport=INPORT2", "-outport1=OUTPORT2_1", "-outport2=OUTPORT2_2", "-cores=CORES"
           ]
         }
       ]

--- a/test/framework/main/perf.json
+++ b/test/framework/main/perf.json
@@ -16,7 +16,8 @@
         "OUTPORT1_1": "1",
         "OUTPORT1_2": "1",
         "PKTGENCOREMASK": "0x1ff",
-        "PKTGENPORT": "[1:2-3].0, [4-5:6].1"
+        "PKTGENPORT": "[1:2-3].0, [4-5:6].1",
+	"CORES": "0-43"
     },
     "tests": [
         {
@@ -60,7 +61,7 @@
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
-                        "./perf_light", "-mode=0", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2"
+                        "./perf_light", "-mode=0", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2", "-cores=CORES"
                     ]
                 },
                 {
@@ -124,7 +125,7 @@
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
-                        "./perf_light", "-mode=0", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2"
+                        "./perf_light", "-mode=0", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2", "-cores=CORES"
                     ]
                 },
                 {
@@ -188,7 +189,7 @@
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
-                        "./perf_light", "-mode=0", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2"
+                        "./perf_light", "-mode=0", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2", "-cores=CORES"
                     ]
                 },
                 {
@@ -252,7 +253,7 @@
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
-                        "./perf_light", "-mode=1", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2"
+                        "./perf_light", "-mode=1", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2", "-cores=CORES"
                     ]
                 },
                 {
@@ -316,7 +317,7 @@
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
-                        "./perf_light", "-mode=1", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2"
+                        "./perf_light", "-mode=1", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2", "-cores=CORES"
                     ]
                 },
                 {
@@ -380,7 +381,7 @@
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
-                        "./perf_light", "-mode=1", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2"
+                        "./perf_light", "-mode=1", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2", "-cores=CORES"
                     ]
                 },
                 {
@@ -444,7 +445,7 @@
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
-                        "./perf_light", "-mode=2", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2"
+                        "./perf_light", "-mode=2", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2", "-cores=CORES"
                     ]
                 },
                 {
@@ -508,7 +509,7 @@
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
-                        "./perf_light", "-mode=2", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2"
+                        "./perf_light", "-mode=2", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2", "-cores=CORES"
                     ]
                 },
                 {
@@ -572,7 +573,7 @@
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
-                        "./perf_light", "-mode=2", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2"
+                        "./perf_light", "-mode=2", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2", "-cores=CORES"
                     ]
                 },
                 {
@@ -636,7 +637,7 @@
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
-                        "./perf_main", "-load=1000", "-loadRW=50", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2"
+                        "./perf_main", "-load=1000", "-loadRW=50", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2", "-cores=CORES"
                     ]
                 },
                 {
@@ -700,7 +701,7 @@
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
-                        "./perf_main", "-load=1000", "-loadRW=50", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2"
+                        "./perf_main", "-load=1000", "-loadRW=50", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2", "-cores=CORES"
                     ]
                 },
                 {
@@ -764,7 +765,7 @@
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
-                        "./perf_main", "-load=1000", "-loadRW=50", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2"
+                        "./perf_main", "-load=1000", "-loadRW=50", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2", "-cores=CORES"
                     ]
                 },
                 {
@@ -828,7 +829,7 @@
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
-                        "./perf_main", "-load=1000", "-loadRW=50", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2"
+                        "./perf_main", "-load=1000", "-loadRW=50", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2", "-cores=CORES"
                     ]
                 },
                 {
@@ -892,7 +893,7 @@
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
-                        "./perf_main", "-load=1000", "-loadRW=0", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2"
+                        "./perf_main", "-load=1000", "-loadRW=0", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2", "-cores=CORES"
                     ]
                 },
                 {
@@ -956,7 +957,7 @@
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
-                        "./perf_main", "-load=1000", "-loadRW=0", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2"
+                        "./perf_main", "-load=1000", "-loadRW=0", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2", "-cores=CORES"
                     ]
                 },
                 {
@@ -1020,7 +1021,7 @@
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
-                        "./perf_main", "-load=1000", "-loadRW=0", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2"
+                        "./perf_main", "-load=1000", "-loadRW=0", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2", "-cores=CORES"
                     ]
                 },
                 {
@@ -1084,7 +1085,7 @@
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
-                        "./perf_main", "-load=1000", "-loadRW=0", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2"
+                        "./perf_main", "-load=1000", "-loadRW=0", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2", "-cores=CORES"
                     ]
                 },
                 {
@@ -1148,7 +1149,7 @@
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
-                        "./perf_main", "-load=500", "-loadRW=0", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2"
+                        "./perf_main", "-load=500", "-loadRW=0", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2", "-cores=CORES"
                     ]
                 },
                 {
@@ -1212,7 +1213,7 @@
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
-                        "./perf_main", "-load=500", "-loadRW=0", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2"
+                        "./perf_main", "-load=500", "-loadRW=0", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2", "-cores=CORES"
                     ]
                 },
                 {
@@ -1276,7 +1277,7 @@
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
-                        "./perf_main", "-load=500", "-loadRW=0", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2"
+                        "./perf_main", "-load=500", "-loadRW=0", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2", "-cores=CORES"
                     ]
                 },
                 {
@@ -1340,7 +1341,7 @@
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
-                        "./perf_main", "-load=500", "-loadRW=0", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2"
+                        "./perf_main", "-load=500", "-loadRW=0", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2", "-cores=CORES"
                     ]
                 },
                 {
@@ -1404,7 +1405,7 @@
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
-                        "./perf_main", "-load=250", "-loadRW=0", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2"
+                        "./perf_main", "-load=250", "-loadRW=0", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2", "-cores=CORES"
                     ]
                 },
                 {
@@ -1468,7 +1469,7 @@
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
-                        "./perf_main", "-load=250", "-loadRW=0", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2"
+                        "./perf_main", "-load=250", "-loadRW=0", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2", "-cores=CORES"
                     ]
                 },
                 {
@@ -1532,7 +1533,7 @@
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
-                        "./perf_main", "-load=250", "-loadRW=0", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2"
+                        "./perf_main", "-load=250", "-loadRW=0", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2", "-cores=CORES"
                     ]
                 },
                 {
@@ -1596,7 +1597,7 @@
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
-                        "./perf_main", "-load=250", "-loadRW=0", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2"
+                        "./perf_main", "-load=250", "-loadRW=0", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2", "-cores=CORES"
                     ]
                 },
                 {
@@ -1660,7 +1661,7 @@
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
-                        "./perf_seq", "-load=250", "-mode=2", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2"
+                        "./perf_seq", "-load=250", "-mode=2", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2", "-cores=CORES"
                     ]
                 },
                 {
@@ -1724,7 +1725,7 @@
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
-                        "./perf_seq", "-load=250", "-mode=2", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2"
+                        "./perf_seq", "-load=250", "-mode=2", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2", "-cores=CORES"
                     ]
                 },
                 {
@@ -1788,7 +1789,7 @@
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
-                        "./perf_seq", "-load=250", "-mode=2", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2"
+                        "./perf_seq", "-load=250", "-mode=2", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2", "-cores=CORES"
                     ]
                 },
                 {
@@ -1852,7 +1853,7 @@
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
-                        "./perf_seq", "-load=250", "-mode=2", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2"
+                        "./perf_seq", "-load=250", "-mode=2", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2", "-cores=CORES"
                     ]
                 },
                 {
@@ -1916,7 +1917,7 @@
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
-                        "./perf_seq", "-load=50", "-mode=2", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2"
+                        "./perf_seq", "-load=50", "-mode=2", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2", "-cores=CORES"
                     ]
                 },
                 {
@@ -1980,7 +1981,7 @@
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
-                        "./perf_seq", "-load=50", "-mode=2", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2"
+                        "./perf_seq", "-load=50", "-mode=2", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2", "-cores=CORES"
                     ]
                 },
                 {
@@ -2044,7 +2045,7 @@
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
-                        "./perf_seq", "-load=50", "-mode=2", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2"
+                        "./perf_seq", "-load=50", "-mode=2", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2", "-cores=CORES"
                     ]
                 },
                 {
@@ -2108,7 +2109,7 @@
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
-                        "./perf_seq", "-load=50", "-mode=2", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2"
+                        "./perf_seq", "-load=50", "-mode=2", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2", "-cores=CORES"
                     ]
                 },
                 {
@@ -2172,7 +2173,7 @@
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
-                        "./perf_seq", "-load=50", "-mode=3", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2"
+                        "./perf_seq", "-load=50", "-mode=3", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2", "-cores=CORES"
                     ]
                 },
                 {
@@ -2236,7 +2237,7 @@
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
-                        "./perf_seq", "-load=50", "-mode=3", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2"
+                        "./perf_seq", "-load=50", "-mode=3", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2", "-cores=CORES"
                     ]
                 },
                 {
@@ -2300,7 +2301,7 @@
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
-                        "./perf_seq", "-load=50", "-mode=3", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2"
+                        "./perf_seq", "-load=50", "-mode=3", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2", "-cores=CORES"
                     ]
                 },
                 {
@@ -2364,7 +2365,7 @@
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
-                        "./perf_seq", "-load=50", "-mode=3", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2"
+                        "./perf_seq", "-load=50", "-mode=3", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2", "-cores=CORES"
                     ]
                 },
                 {
@@ -2428,7 +2429,7 @@
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
-                        "./perf_seq", "-load=25", "-mode=3", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2"
+                        "./perf_seq", "-load=25", "-mode=3", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2", "-cores=CORES"
                     ]
                 },
                 {
@@ -2492,7 +2493,7 @@
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
-                        "./perf_seq", "-load=25", "-mode=3", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2"
+                        "./perf_seq", "-load=25", "-mode=3", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2", "-cores=CORES"
                     ]
                 },
                 {
@@ -2556,7 +2557,7 @@
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
-                        "./perf_seq", "-load=25", "-mode=3", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2"
+                        "./perf_seq", "-load=25", "-mode=3", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2", "-cores=CORES"
                     ]
                 },
                 {
@@ -2620,7 +2621,7 @@
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
-                        "./perf_seq", "-load=25", "-mode=3", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2"
+                        "./perf_seq", "-load=25", "-mode=3", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2", "-cores=CORES"
                     ]
                 },
                 {
@@ -2684,7 +2685,7 @@
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
-                        "./perf_seq", "-load=25", "-mode=13", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2"
+                        "./perf_seq", "-load=25", "-mode=13", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2", "-cores=CORES"
                     ]
                 },
                 {
@@ -2748,7 +2749,7 @@
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
-                        "./perf_seq", "-load=25", "-mode=13", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2"
+                        "./perf_seq", "-load=25", "-mode=13", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2", "-cores=CORES"
                     ]
                 },
                 {
@@ -2812,7 +2813,7 @@
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
-                        "./perf_seq", "-load=25", "-mode=13", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2"
+                        "./perf_seq", "-load=25", "-mode=13", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2", "-cores=CORES"
                     ]
                 },
                 {
@@ -2876,7 +2877,7 @@
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
-                        "./perf_seq", "-load=25", "-mode=13", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2"
+                        "./perf_seq", "-load=25", "-mode=13", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2", "-cores=CORES"
                     ]
                 },
                 {
@@ -2940,7 +2941,7 @@
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
-                        "./perf_seq", "-load=25", "-mode=4", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2"
+                        "./perf_seq", "-load=25", "-mode=4", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2", "-cores=CORES"
                     ]
                 },
                 {
@@ -3004,7 +3005,7 @@
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
-                        "./perf_seq", "-load=25", "-mode=4", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2"
+                        "./perf_seq", "-load=25", "-mode=4", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2", "-cores=CORES"
                     ]
                 },
                 {
@@ -3068,7 +3069,7 @@
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
-                        "./perf_seq", "-load=25", "-mode=4", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2"
+                        "./perf_seq", "-load=25", "-mode=4", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2", "-cores=CORES"
                     ]
                 },
                 {
@@ -3132,7 +3133,7 @@
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
-                        "./perf_seq", "-load=25", "-mode=4", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2"
+                        "./perf_seq", "-load=25", "-mode=4", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2", "-cores=CORES"
                     ]
                 },
                 {
@@ -3196,7 +3197,7 @@
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
-                        "./perf_seq", "-load=25", "-mode=14", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2"
+                        "./perf_seq", "-load=25", "-mode=14", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2", "-cores=CORES"
                     ]
                 },
                 {
@@ -3260,7 +3261,7 @@
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
-                        "./perf_seq", "-load=25", "-mode=14", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2"
+                        "./perf_seq", "-load=25", "-mode=14", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2", "-cores=CORES"
                     ]
                 },
                 {
@@ -3324,7 +3325,7 @@
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
-                        "./perf_seq", "-load=25", "-mode=14", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2"
+                        "./perf_seq", "-load=25", "-mode=14", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2", "-cores=CORES"
                     ]
                 },
                 {
@@ -3388,7 +3389,7 @@
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
-                        "./perf_seq", "-load=25", "-mode=14", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2"
+                        "./perf_seq", "-load=25", "-mode=14", "-inport=INPORT1", "-outport1=OUTPORT1_1", "-outport2=OUTPORT1_2", "-cores=CORES"
                     ]
                 },
                 {
@@ -3452,7 +3453,7 @@
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
-                        "./ipsec", "-inport=INPORT1", "-outport=OUTPORT1_1"
+                        "./ipsec", "-inport=INPORT1", "-outport=OUTPORT1_1", "-cores=CORES"
                     ]
                 },
                 {
@@ -3516,7 +3517,7 @@
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
-                        "./ipsec", "-inport=INPORT1", "-outport=OUTPORT1_1"
+                        "./ipsec", "-inport=INPORT1", "-outport=OUTPORT1_1", "-cores=CORES"
                     ]
                 },
                 {
@@ -3580,7 +3581,7 @@
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
-                        "./ipsec", "-inport=INPORT1", "-outport=OUTPORT1_1"
+                        "./ipsec", "-inport=INPORT1", "-outport=OUTPORT1_1", "-cores=CORES"
                     ]
                 },
                 {
@@ -3644,7 +3645,7 @@
                     "image-name": "nff-go-performance",
                     "app-type": "TestAppGo",
                     "exec-cmd": [
-                        "./ipsec", "-inport=INPORT1", "-outport=OUTPORT1_1"
+                        "./ipsec", "-inport=INPORT1", "-outport=OUTPORT1_1", "-cores=CORES"
                     ]
                 },
                 {

--- a/test/performance/ipsec.go
+++ b/test/performance/ipsec.go
@@ -21,11 +21,13 @@ func main() {
 	inport := flag.Uint("inport", 0, "port for receiver")
 	noscheduler := flag.Bool("no-scheduler", false, "disable scheduler")
 	dpdkLogLevel := flag.String("dpdk", "--log-level=0", "Passes an arbitrary argument to dpdk EAL")
+	cores := flag.String("cores", "0-43", "Cores mask. Avoid hyperthreading here")
 	flag.Parse()
 
 	config := flow.Config{
 		DisableScheduler: *noscheduler,
 		DPDKArgs:         []string{*dpdkLogLevel},
+		CPUList:	  *cores,
 	}
 	flow.CheckFatal(flow.SystemInit(&config))
 

--- a/test/performance/perf_light.go
+++ b/test/performance/perf_light.go
@@ -19,12 +19,14 @@ func main() {
 	inport := flag.Uint("inport", 0, "port for receiver")
 	noscheduler := flag.Bool("no-scheduler", false, "disable scheduler")
 	dpdkLogLevel := flag.String("dpdk", "--log-level=0", "Passes an arbitrary argument to dpdk EAL")
+	cores := flag.String("cores", "0-43", "Cores mask. Avoid hyperthreading here")
 	flag.Parse()
 
 	// Initialize NFF-GO library
 	config := flow.Config{
 		DisableScheduler: *noscheduler,
 		DPDKArgs:         []string{*dpdkLogLevel},
+		CPUList:          *cores,
 	}
 	flow.CheckFatal(flow.SystemInit(&config))
 

--- a/test/performance/perf_main.go
+++ b/test/performance/perf_main.go
@@ -25,12 +25,14 @@ func main() {
 	inport := flag.Uint("inport", 0, "port for receiver")
 	noscheduler := flag.Bool("no-scheduler", false, "disable scheduler")
 	dpdkLogLevel := flag.String("dpdk", "--log-level=0", "Passes an arbitrary argument to dpdk EAL")
+	cores := flag.String("cores", "0-43", "Cores mask. Avoid hyperthreading here")
 	flag.Parse()
 
 	// Initialize NFF-GO library
 	config := flow.Config{
 		DisableScheduler: *noscheduler,
 		DPDKArgs:         []string{*dpdkLogLevel},
+		CPUList:          *cores,
 	}
 	flow.CheckFatal(flow.SystemInit(&config))
 

--- a/test/performance/perf_seq.go
+++ b/test/performance/perf_seq.go
@@ -25,12 +25,14 @@ func main() {
 	inport := flag.Uint("inport", 0, "port for receiver")
 	noscheduler := flag.Bool("no-scheduler", false, "disable scheduler")
 	dpdkLogLevel := flag.String("dpdk", "--log-level=0", "Passes an arbitrary argument to dpdk EAL")
+	cores := flag.String("cores", "0-43", "Cores mask. Avoid hyperthreading here")
 	flag.Parse()
 
 	// Initialize NFF-GO library
 	config := flow.Config{
 		DisableScheduler: *noscheduler,
 		DPDKArgs:         []string{*dpdkLogLevel},
+		CPUList:          *cores,
 	}
 	flow.CheckFatal(flow.SystemInit(&config))
 


### PR DESCRIPTION
New scheduler model will allow more clones, so at some point framework
will start to use hyperthreading cores which is not expected behavior.