### PR TITLE
Increased number of rings between Flow Functions based on RSS

### DIFF
--- a/flow/flow.go
+++ b/flow/flow.go
@@ -48,7 +48,7 @@ var schedState *scheduler
 var vEach [10][burstSize]uint8
 
 type processSegment struct {
-	out      []*low.Ring
+	out      []low.Rings
 	contexts []UserContext
 	stype    uint8
 }
@@ -56,9 +56,10 @@ type processSegment struct {
 // Flow is an abstraction for connecting flow functions with each other.
 // Flow shouldn't be understood in any way beyond this.
 type Flow struct {
-	current  *low.Ring
+	current  low.Rings
 	segment  *processSegment
 	previous **Func
+	inIndexNumber int32
 }
 
 type partitionCtx struct {
@@ -138,41 +139,41 @@ type Kni struct {
 }
 
 type receiveParameters struct {
-	out  *low.Ring
+	out  low.Rings
 	port *low.Port
 	kni  bool
 }
 
-func addReceiver(portId uint16, kni bool, out *low.Ring) {
+func addReceiver(portId uint16, kni bool, out low.Rings, inIndexNumber int32) {
 	par := new(receiveParameters)
 	par.port = low.GetPort(portId)
 	par.out = out
 	par.kni = kni
 	if kni {
-		schedState.addFF("KNI receiver", nil, recvKNI, nil, par, nil, sendReceiveKNI)
+		schedState.addFF("KNI receiver", nil, recvKNI, nil, par, nil, sendReceiveKNI, 0)
 	} else {
-		schedState.addFF("receiver", nil, recvRSS, nil, par, nil, receiveRSS)
+		schedState.addFF("receiver", nil, recvRSS, nil, par, nil, receiveRSS, inIndexNumber)
 	}
 }
 
 type generateParameters struct {
-	out                    *low.Ring
+	out                    low.Rings
 	generateFunction       GenerateFunction
 	vectorGenerateFunction VectorGenerateFunction
 	mempool                *low.Mempool
 	targetSpeed            float64
 }
 
-func addGenerator(out *low.Ring, generateFunction GenerateFunction, context UserContext) {
+func addGenerator(out low.Rings, generateFunction GenerateFunction, context UserContext) {
 	par := new(generateParameters)
 	par.out = out
 	par.generateFunction = generateFunction
 	ctx := make([]UserContext, 1, 1)
 	ctx[0] = context
-	schedState.addFF("generator", nil, nil, pGenerate, par, &ctx, generate)
+	schedState.addFF("generator", nil, nil, pGenerate, par, &ctx, generate, 0)
 }
 
-func addFastGenerator(out *low.Ring, generateFunction GenerateFunction,
+func addFastGenerator(out low.Rings, generateFunction GenerateFunction,
 	vectorGenerateFunction VectorGenerateFunction, targetSpeed uint64, context UserContext) {
 	par := new(generateParameters)
 	par.out = out
@@ -182,41 +183,41 @@ func addFastGenerator(out *low.Ring, generateFunction GenerateFunction,
 	par.targetSpeed = float64(targetSpeed)
 	ctx := make([]UserContext, 1, 1)
 	ctx[0] = context
-	schedState.addFF("fast generator", nil, nil, pFastGenerate, par, &ctx, fastGenerate)
+	schedState.addFF("fast generator", nil, nil, pFastGenerate, par, &ctx, fastGenerate, 0)
 }
 
 type sendParameters struct {
-	in    *low.Ring
+	in    low.Rings
 	queue int16
 	port  uint16
 }
 
-func addSender(port uint16, queue int16, in *low.Ring) {
+func addSender(port uint16, queue int16, in low.Rings, inIndexNumber int32) {
 	par := new(sendParameters)
 	par.port = port
 	par.queue = queue
 	par.in = in
 	if queue != -1 {
-		schedState.addFF("sender", nil, send, nil, par, nil, sendReceiveKNI)
+		schedState.addFF("sender", nil, send, nil, par, nil, sendReceiveKNI, inIndexNumber)
 	} else {
-		schedState.addFF("KNI sender", nil, send, nil, par, nil, sendReceiveKNI)
+		schedState.addFF("KNI sender", nil, send, nil, par, nil, sendReceiveKNI, inIndexNumber)
 	}
 }
 
 type copyParameters struct {
-	in      *low.Ring
-	out     *low.Ring
-	outCopy *low.Ring
+	in      low.Rings
+	out     low.Rings
+	outCopy low.Rings
 	mempool *low.Mempool
 }
 
-func addCopier(in *low.Ring, out *low.Ring, outCopy *low.Ring) {
+func addCopier(in low.Rings, out low.Rings, outCopy low.Rings, inIndexNumber int32) {
 	par := new(copyParameters)
 	par.in = in
 	par.out = out
 	par.outCopy = outCopy
 	par.mempool = low.CreateMempool("copy")
-	schedState.addFF("copy", nil, nil, pcopy, par, nil, segmentCopy)
+	schedState.addFF("copy", nil, nil, pcopy, par, nil, segmentCopy, inIndexNumber)
 }
 
 func makePartitioner(N uint64, M uint64) *Func {
@@ -262,32 +263,32 @@ func makeHandler(handleFunction HandleFunction, vectorHandleFunction VectorHandl
 }
 
 type writeParameters struct {
-	in       *low.Ring
+	in       low.Rings
 	filename string
 }
 
-func addWriter(filename string, in *low.Ring) {
+func addWriter(filename string, in low.Rings, inIndexNumber int32) {
 	par := new(writeParameters)
 	par.in = in
 	par.filename = filename
-	schedState.addFF("writer", write, nil, nil, par, nil, readWrite)
+	schedState.addFF("writer", write, nil, nil, par, nil, readWrite, inIndexNumber)
 }
 
 type readParameters struct {
-	out      *low.Ring
+	out      low.Rings
 	filename string
 	repcount int32
 }
 
-func addReader(filename string, out *low.Ring, repcount int32) {
+func addReader(filename string, out low.Rings, repcount int32) {
 	par := new(readParameters)
 	par.out = out
 	par.filename = filename
 	par.repcount = repcount
-	schedState.addFF("reader", read, nil, nil, par, nil, readWrite)
+	schedState.addFF("reader", read, nil, nil, par, nil, readWrite, 0)
 }
 
-func makeSlice(out *low.Ring, segment *processSegment) *Func {
+func makeSlice(out low.Rings, segment *processSegment) *Func {
 	f := new(Func)
 	f.sFunc = constructSlice
 	f.vFunc = vConstructSlice
@@ -298,22 +299,22 @@ func makeSlice(out *low.Ring, segment *processSegment) *Func {
 }
 
 type segmentParameters struct {
-	in        *low.Ring
-	out       *([](*low.Ring))
+	in        low.Rings
+	out       *([]low.Rings)
 	firstFunc *Func
 	stype     *uint8
 }
 
-func addSegment(in *low.Ring, first *Func) *processSegment {
+func addSegment(in low.Rings, first *Func, inIndexNumber int32) *processSegment {
 	par := new(segmentParameters)
 	par.in = in
 	par.firstFunc = first
 	segment := new(processSegment)
-	segment.out = make([](*low.Ring), 0, 0)
+	segment.out = make([]low.Rings, 0, 0)
 	segment.contexts = make([](UserContext), 0, 0)
 	par.out = &segment.out
 	par.stype = &segment.stype
-	schedState.addFF("segment", nil, nil, segmentProcess, par, &segment.contexts, segmentCopy)
+	schedState.addFF("segment", nil, nil, segmentProcess, par, &segment.contexts, segmentCopy, inIndexNumber)
 	return segment
 }
 
@@ -360,6 +361,7 @@ type port struct {
 	willKNI        bool // will this port has assigned KNI device
 	port           uint16
 	MAC            [common.EtherAddrLen]uint8
+	InIndex     int32
 }
 
 // Config is a struct with all parameters, which user can pass to NFF-GO library
@@ -410,6 +412,11 @@ type Config struct {
 	// Maximum simultaneous receives that should handle all
 	// input at your network card
 	MaxRecv int
+	// Limits parallel instances. 1 for one instance, 1000 for RSS count determine instances
+	MaxInIndex int32
+	// Scheduler should clone functions even if ti can lead to reordering.
+	// This option should be switch off for all high level reassembling like TCP or HTTP
+	RestrictedCloning bool
 }
 
 // SystemInit is initialization of system. This function should be always called before graph construction.
@@ -432,8 +439,9 @@ func SystemInit(args *Config) error {
 	schedulerOffRemove := args.PersistentClones
 	stopDedicatedCore := args.StopOnDedicatedCore
 	hwtxchecksum = args.HWTXChecksum
+	anyway := !args.RestrictedCloning
 
-	mbufNumber := uint(4 * 8191)
+	mbufNumber := uint(8191)
 	if args.MbufNumber != 0 {
 		mbufNumber = args.MbufNumber
 	}
@@ -443,7 +451,7 @@ func SystemInit(args *Config) error {
 		mbufCacheSize = args.MbufCacheSize
 	}
 
-	sizeMultiplier = 256
+	sizeMultiplier = 64
 	if args.RingSize != 0 {
 		sizeMultiplier = args.RingSize
 	}
@@ -478,9 +486,17 @@ func SystemInit(args *Config) error {
 	}
 	common.SetLogType(logType)
 
-	maxRecv := 3
+	maxRecv := 2
 	if args.MaxRecv != 0 {
 		needKNI = args.MaxRecv
+	}
+
+	maxInIndex := int32(16)
+	if schedulerOff == true {
+		maxInIndex = 1
+	}
+	if args.MaxInIndex != 0 {
+		maxInIndex = args.MaxInIndex
 	}
 
 	argc, argv := low.InitDPDKArguments(args.DPDKArgs)
@@ -494,13 +510,18 @@ func SystemInit(args *Config) error {
 	createdPorts = make([]port, low.GetPortsNumber(), low.GetPortsNumber())
 	for i := range createdPorts {
 		createdPorts[i].port = uint16(i)
+		if maxInIndex > low.CheckPortRSS(createdPorts[i].port) {
+			createdPorts[i].InIndex = low.CheckPortRSS(createdPorts[i].port)
+		} else {
+			createdPorts[i].InIndex = maxInIndex
+		}
 	}
 	portPair = make(map[uint32](*port))
 	// Init scheduler
 	common.LogTitle(common.Initialization, "------------***------ Initializing scheduler -----***------------")
-	StopRing := low.CreateRing(burstSize * sizeMultiplier)
+	StopRing := low.CreateRings(burstSize * sizeMultiplier, 50 /*Maximum possible rings*/)
 	common.LogDebug(common.Initialization, "Scheduler can use cores:", cpus)
-	schedState = newScheduler(cpus, schedulerOff, schedulerOffRemove, stopDedicatedCore, StopRing, checkTime, debugTime, maxPacketsToClone, maxRecv)
+	schedState = newScheduler(cpus, schedulerOff, schedulerOffRemove, stopDedicatedCore, StopRing, checkTime, debugTime, maxPacketsToClone, maxRecv, anyway)
 	// Init packet processing
 	packet.SetHWTXChecksumFlag(hwtxchecksum)
 	for i := 0; i < 10; i++ {
@@ -522,7 +543,7 @@ func SystemStart() error {
 	for i := range createdPorts {
 		if createdPorts[i].wasRequested {
 			if err := low.CreatePort(createdPorts[i].port, createdPorts[i].willReceive,
-				uint16(createdPorts[i].txQueuesNumber), true, hwtxchecksum); err != nil {
+				uint16(createdPorts[i].txQueuesNumber), true, hwtxchecksum, createdPorts[i].InIndex); err != nil {
 				return err
 			}
 		}
@@ -572,7 +593,7 @@ func SetSenderFile(IN *Flow, filename string) error {
 	if err := checkFlow(IN); err != nil {
 		return err
 	}
-	addWriter(filename, finishFlow(IN))
+	addWriter(filename, finishFlow(IN), IN.inIndexNumber)
 	return nil
 }
 
@@ -581,9 +602,9 @@ func SetSenderFile(IN *Flow, filename string) error {
 // file is read infinitely in circle.
 // Returns new opened flow with read packets.
 func SetReceiverFile(filename string, repcount int32) (OUT *Flow) {
-	ring := low.CreateRing(burstSize * sizeMultiplier)
-	addReader(filename, ring, repcount)
-	return newFlow(ring)
+	rings := low.CreateRings(burstSize * sizeMultiplier, 1)
+	addReader(filename, rings, repcount)
+	return newFlow(rings, 1)
 }
 
 // SetReceiver adds receive function to flow graph.
@@ -599,9 +620,9 @@ func SetReceiver(portId uint16) (OUT *Flow, err error) {
 	}
 	createdPorts[portId].wasRequested = true
 	createdPorts[portId].willReceive = true
-	ring := low.CreateRing(burstSize * sizeMultiplier)
-	addReceiver(portId, false, ring)
-	return newFlow(ring), nil
+	rings := low.CreateRings(burstSize * sizeMultiplier, createdPorts[portId].InIndex)
+	addReceiver(portId, false, rings, createdPorts[portId].InIndex)
+	return newFlow(rings, createdPorts[portId].InIndex), nil
 }
 
 // SetReceiverKNI adds function receive from KNI to flow graph.
@@ -609,9 +630,9 @@ func SetReceiver(portId uint16) (OUT *Flow, err error) {
 // Receive queue will be added to port automatically.
 // Returns new opened flow with received packets
 func SetReceiverKNI(kni *Kni) (OUT *Flow) {
-	ring := low.CreateRing(burstSize * sizeMultiplier)
-	addReceiver(kni.portId, true, ring)
-	return newFlow(ring)
+	rings := low.CreateRings(burstSize * sizeMultiplier, 1)
+	addReceiver(kni.portId, true, rings, 1)
+	return newFlow(rings, 1)
 }
 
 // SetFastGenerator adds clonable generate function to flow graph.
@@ -619,13 +640,13 @@ func SetReceiverKNI(kni *Kni) (OUT *Flow) {
 // Returns new open flow with generated packets.
 // Function tries to achieve target speed by cloning.
 func SetFastGenerator(f GenerateFunction, targetSpeed uint64, context UserContext) (OUT *Flow, err error) {
-	ring := low.CreateRing(burstSize * sizeMultiplier)
+	rings := low.CreateRings(burstSize * sizeMultiplier, 1)
 	if targetSpeed > 0 {
-		addFastGenerator(ring, f, nil, targetSpeed, context)
+		addFastGenerator(rings, f, nil, targetSpeed, context)
 	} else {
 		return nil, common.WrapWithNFError(nil, "Target speed value should be > 0", common.BadArgument)
 	}
-	return newFlow(ring), nil
+	return newFlow(rings, 1), nil
 }
 
 // SetVectorFastGenerator adds clonable vector generate function to flow graph.
@@ -633,13 +654,13 @@ func SetFastGenerator(f GenerateFunction, targetSpeed uint64, context UserContex
 // Returns new open flow with generated packets.
 // Function tries to achieve target speed by cloning.
 func SetVectorFastGenerator(f VectorGenerateFunction, targetSpeed uint64, context UserContext) (OUT *Flow, err error) {
-	ring := low.CreateRing(burstSize * sizeMultiplier)
+	rings := low.CreateRings(burstSize * sizeMultiplier, 1)
 	if targetSpeed > 0 {
-		addFastGenerator(ring, nil, f, targetSpeed, context)
+		addFastGenerator(rings, nil, f, targetSpeed, context)
 	} else {
 		return nil, common.WrapWithNFError(nil, "Target speed value should be > 0", common.BadArgument)
 	}
-	return newFlow(ring), nil
+	return newFlow(rings, 1), nil
 }
 
 // SetGenerator adds non-clonable generate flow function to flow graph.
@@ -648,9 +669,9 @@ func SetVectorFastGenerator(f VectorGenerateFunction, targetSpeed uint64, contex
 // Single packet non-clonable flow function will be added. It can be used for waiting of
 // input user packets.
 func SetGenerator(f GenerateFunction, context UserContext) (OUT *Flow) {
-	ring := low.CreateRing(burstSize * sizeMultiplier)
-	addGenerator(ring, f, context)
-	return newFlow(ring)
+	rings := low.CreateRings(burstSize * sizeMultiplier, 1)
+	addGenerator(rings, f, context)
+	return newFlow(rings, 1)
 }
 
 // SetSender adds send function to flow graph.
@@ -664,7 +685,7 @@ func SetSender(IN *Flow, portId uint16) error {
 		return common.WrapWithNFError(nil, "Requested send port exceeds number of ports which can be used by DPDK (bind to DPDK).", common.ReqTooManyPorts)
 	}
 	createdPorts[portId].wasRequested = true
-	addSender(portId, createdPorts[portId].txQueuesNumber, finishFlow(IN))
+	addSender(portId, createdPorts[portId].txQueuesNumber, finishFlow(IN), IN.inIndexNumber)
 	createdPorts[portId].txQueuesNumber++
 	return nil
 }
@@ -676,7 +697,7 @@ func SetSenderKNI(IN *Flow, kni *Kni) error {
 	if err := checkFlow(IN); err != nil {
 		return err
 	}
-	addSender(kni.portId, -1, finishFlow(IN))
+	addSender(kni.portId, -1, finishFlow(IN), IN.inIndexNumber)
 	return nil
 }
 
@@ -686,19 +707,19 @@ func SetCopier(IN *Flow) (OUT *Flow, err error) {
 	if err := checkFlow(IN); err != nil {
 		return nil, err
 	}
-	ringFirst := low.CreateRing(burstSize * sizeMultiplier)
-	ringSecond := low.CreateRing(burstSize * sizeMultiplier)
+	ringFirst := low.CreateRings(burstSize * sizeMultiplier, IN.inIndexNumber)
+	ringSecond := low.CreateRings(burstSize * sizeMultiplier, IN.inIndexNumber)
 	if IN.segment == nil {
-		addCopier(IN.current, ringFirst, ringSecond)
+		addCopier(IN.current, ringFirst, ringSecond, IN.inIndexNumber)
 	} else {
-		tRing := low.CreateRing(burstSize * sizeMultiplier)
+		tRing := low.CreateRings(burstSize * sizeMultiplier, IN.inIndexNumber)
 		ms := makeSlice(tRing, IN.segment)
 		segmentInsert(IN, ms, false, nil, 0, 0)
-		addCopier(tRing, ringFirst, ringSecond)
+		addCopier(tRing, ringFirst, ringSecond, IN.inIndexNumber)
 		IN.segment = nil
 	}
 	IN.current = ringFirst
-	return newFlow(ringSecond), nil
+	return newFlow(ringSecond, IN.inIndexNumber), nil
 }
 
 // SetPartitioner adds partition function to flow graph.
@@ -719,7 +740,7 @@ func SetPartitioner(IN *Flow, N uint64, M uint64) (OUT *Flow, err error) {
 	if err := segmentInsert(IN, partition, false, *ctx, 0, 0); err != nil {
 		return nil, err
 	}
-	return newFlowSegment(IN.segment, &partition.next[1]), nil
+	return newFlowSegment(IN.segment, &partition.next[1], IN.inIndexNumber), nil
 }
 
 // SetSeparator adds separate function to flow graph.
@@ -731,7 +752,7 @@ func SetSeparator(IN *Flow, separateFunction SeparateFunction, context UserConte
 	if err := segmentInsert(IN, separate, false, context, 1, 1); err != nil {
 		return nil, err
 	}
-	return newFlowSegment(IN.segment, &separate.next[0]), nil
+	return newFlowSegment(IN.segment, &separate.next[0], IN.inIndexNumber), nil
 }
 
 // SetVectorSeparator adds vector separate function to flow graph.
@@ -743,7 +764,7 @@ func SetVectorSeparator(IN *Flow, vectorSeparateFunction VectorSeparateFunction,
 	if err := segmentInsert(IN, separate, false, context, 2, 1); err != nil {
 		return nil, err
 	}
-	return newFlowSegment(IN.segment, &separate.next[0]), nil
+	return newFlowSegment(IN.segment, &separate.next[0], IN.inIndexNumber), nil
 }
 
 // SetSplitter adds split function to flow graph.
@@ -759,7 +780,7 @@ func SetSplitter(IN *Flow, splitFunction SplitFunction, flowNumber uint, context
 	segmentInsert(IN, split, true, context, 1, 0)
 	OutArray = make([](*Flow), flowNumber, flowNumber)
 	for i := range OutArray {
-		OutArray[i] = newFlowSegment(IN.segment, &split.next[i])
+		OutArray[i] = newFlowSegment(IN.segment, &split.next[i], IN.inIndexNumber)
 	}
 	return OutArray, nil
 }
@@ -777,7 +798,7 @@ func SetVectorSplitter(IN *Flow, vectorSplitFunction VectorSplitFunction, flowNu
 	segmentInsert(IN, split, true, context, 2, 0)
 	OutArray = make([](*Flow), flowNumber, flowNumber)
 	for i := range OutArray {
-		OutArray[i] = newFlowSegment(IN.segment, &split.next[i])
+		OutArray[i] = newFlowSegment(IN.segment, &split.next[i], IN.inIndexNumber)
 	}
 	return OutArray, nil
 }
@@ -833,7 +854,7 @@ func SetHandlerDrop(IN *Flow, separateFunction SeparateFunction, context UserCon
 	if err := segmentInsert(IN, separate, false, context, 1, 1); err != nil {
 		return err
 	}
-	return SetStopper(newFlowSegment(IN.segment, &separate.next[0]))
+	return SetStopper(newFlowSegment(IN.segment, &separate.next[0], IN.inIndexNumber))
 }
 
 // SetVectorHandlerDrop adds vector handle function to flow graph.
@@ -845,7 +866,7 @@ func SetVectorHandlerDrop(IN *Flow, vectorSeparateFunction VectorSeparateFunctio
 	if err := segmentInsert(IN, separate, false, context, 2, 1); err != nil {
 		return err
 	}
-	return SetStopper(newFlowSegment(IN.segment, &separate.next[0]))
+	return SetStopper(newFlowSegment(IN.segment, &separate.next[0], IN.inIndexNumber))
 }
 
 // SetMerger adds merge function to flow graph.
@@ -853,21 +874,27 @@ func SetVectorHandlerDrop(IN *Flow, vectorSeparateFunction VectorSeparateFunctio
 // All input flows will be closed. All packets from all these flows will be sent to new flow.
 // This function isn't use any cores. It changes output flows of other functions at initialization stage.
 func SetMerger(InArray ...*Flow) (OUT *Flow, err error) {
-	ring := low.CreateRing(burstSize * sizeMultiplier)
+	max := int32(0)
+	for i := range InArray {
+		if InArray[i].inIndexNumber > max {
+			max = InArray[i].inIndexNumber
+		}
+	}
+	rings := low.CreateRings(burstSize * sizeMultiplier, max)
 	for i := range InArray {
 		if err := checkFlow(InArray[i]); err != nil {
 			return nil, err
 		}
 		if InArray[i].segment == nil {
-			merge(InArray[i].current, ring)
+			merge(InArray[i].current, rings)
 			closeFlow(InArray[i])
 		} else {
 			// TODO merge finishes segment even if this is merge inside it. Need to optimize.
-			ms := makeSlice(ring, InArray[i].segment)
+			ms := makeSlice(rings, InArray[i].segment)
 			segmentInsert(InArray[i], ms, true, nil, 0, 0)
 		}
 	}
-	return newFlow(ring), nil
+	return newFlow(rings, max), nil
 }
 
 // GetPortMACAddress returns default MAC address of an Ethernet port.
@@ -888,27 +915,28 @@ func SetIPForPort(port uint16, ip uint32) error {
 }
 
 // Service functions for Flow
-func newFlow(ring *low.Ring) *Flow {
+func newFlow(rings low.Rings, inIndexNumber int32) *Flow {
 	OUT := new(Flow)
-	OUT.current = ring
+	OUT.current = rings
+	OUT.inIndexNumber = inIndexNumber
 	openFlowsNumber++
 	return OUT
 }
 
-func newFlowSegment(segment *processSegment, previous **Func) *Flow {
-	OUT := newFlow(nil)
+func newFlowSegment(segment *processSegment, previous **Func, inIndexNumber int32) *Flow {
+	OUT := newFlow(nil, inIndexNumber)
 	OUT.segment = segment
 	OUT.previous = previous
 	return OUT
 }
 
-func finishFlow(IN *Flow) *low.Ring {
-	var ring *low.Ring
+func finishFlow(IN *Flow) low.Rings {
+	var ring low.Rings
 	if IN.segment == nil {
 		ring = IN.current
 		closeFlow(IN)
 	} else {
-		ring = low.CreateRing(burstSize * sizeMultiplier)
+		ring = low.CreateRings(burstSize * sizeMultiplier, IN.inIndexNumber)
 		ms := makeSlice(ring, IN.segment)
 		segmentInsert(IN, ms, true, nil, 0, 0)
 	}
@@ -926,11 +954,12 @@ func segmentInsert(IN *Flow, f *Func, willClose bool, context UserContext, setTy
 		return err
 	}
 	if IN.segment == nil {
-		IN.segment = addSegment(IN.current, f)
+		IN.segment = addSegment(IN.current, f, IN.inIndexNumber)
 		IN.segment.stype = setType
 	} else {
 		if setType > 0 && IN.segment.stype > 0 && setType != IN.segment.stype {
-			ring := low.CreateRing(burstSize * sizeMultiplier)
+			// Try to combine scalar and vector code. Start new segment
+			ring := low.CreateRings(burstSize * sizeMultiplier, IN.inIndexNumber)
 			ms := makeSlice(ring, IN.segment)
 			segmentInsert(IN, ms, false, nil, 0, 0)
 			IN.segment = nil
@@ -939,6 +968,7 @@ func segmentInsert(IN *Flow, f *Func, willClose bool, context UserContext, setTy
 			return nil
 		}
 		if setType > 0 && IN.segment.stype == 0 {
+			// Current segment is universal. Set new scalar/vector type to it
 			IN.segment.stype = setType
 		}
 		*IN.previous = f
@@ -953,7 +983,7 @@ func segmentInsert(IN *Flow, f *Func, willClose bool, context UserContext, setTy
 	return nil
 }
 
-func segmentProcess(parameters interface{}, stopper [2]chan int, report chan reportPair, context []UserContext) {
+func segmentProcess(parameters interface{}, inIndex []int32, stopper [2]chan int, report chan reportPair, context []UserContext) {
 	// For scalar and vector parts
 	lp := parameters.(*segmentParameters)
 	IN := lp.in
@@ -1000,88 +1030,91 @@ func segmentProcess(parameters interface{}, stopper [2]chan int, report chan rep
 			report <- currentSpeed
 			currentSpeed = reportPair{}
 		default:
-			n := IN.DequeueBurst(InputMbufs, burstSize)
-			if n == 0 {
-				if pause != 0 {
-					time.Sleep(time.Duration(pause) * time.Nanosecond)
+			for q := int32(1); q < inIndex[0]+1; q++ {
+				n := IN[inIndex[q]].DequeueBurst(InputMbufs, burstSize)
+				if n == 0 {
+					if pause != 0 {
+						// pause should be non 0 only if function works with ONE inIndex
+						time.Sleep(time.Duration(pause) * time.Nanosecond)
+					}
+					continue
 				}
-				continue
-			}
-			if scalar { // Scalar code
-				for i := uint(0); i < n; i++ {
-					currentFunc := firstFunc
-					tempPacket = packet.ExtractPacket(InputMbufs[i])
-					for {
-						nextIndex := currentFunc.sFunc(tempPacket, currentFunc, context[currentFunc.contextIndex])
-						if currentFunc.followingNumber == 0 {
-							// We have constructSlice -> put packets to output slices
-							OutputMbufs[nextIndex][countOfPackets[nextIndex]] = InputMbufs[i]
-							countOfPackets[nextIndex]++
-							if reportMbits {
-								currentSpeed.Bytes += uint64(tempPacket.GetPacketLen())
+				if scalar { // Scalar code
+					for i := uint(0); i < n; i++ {
+						currentFunc := firstFunc
+						tempPacket = packet.ExtractPacket(InputMbufs[i])
+						for {
+							nextIndex := currentFunc.sFunc(tempPacket, currentFunc, context[currentFunc.contextIndex])
+							if currentFunc.followingNumber == 0 {
+								// We have constructSlice -> put packets to output slices
+								OutputMbufs[nextIndex][countOfPackets[nextIndex]] = InputMbufs[i]
+								countOfPackets[nextIndex]++
+								if reportMbits {
+									currentSpeed.Bytes += uint64(tempPacket.GetPacketLen())
+								}
+								break
 							}
-							break
+							currentFunc = currentFunc.next[nextIndex]
 						}
-						currentFunc = currentFunc.next[nextIndex]
 					}
-				}
-				for index := 0; index < outNumber; index++ {
-					if countOfPackets[index] == 0 {
-						continue
+					for index := 0; index < outNumber; index++ {
+						if countOfPackets[index] == 0 {
+							continue
+						}
+						safeEnqueue(OUT[index][inIndex[q]], OutputMbufs[index], uint(countOfPackets[index]))
+						currentSpeed.Packets += uint64(countOfPackets[index])
+						countOfPackets[index] = 0
 					}
-					safeEnqueue(OUT[index], OutputMbufs[index], uint(countOfPackets[index]))
-					currentSpeed.Packets += uint64(countOfPackets[index])
-					countOfPackets[index] = 0
-				}
-			} else { // Vector code
-				packet.ExtractPackets(tempPackets, InputMbufs, n)
-				def[0].f = firstFunc
-				for i := uint(0); i < burstSize; i++ {
-					def[0].mask[i] = (i < n)
-				}
-				st := 0
-				for st != -1 {
-					cur := def[st].f
-					cur.vFunc(tempPackets, &def[st].mask, &answers, cur, context[cur.contextIndex])
-					if cur.followingNumber == 0 {
-						// We have constructSlice -> put packets inside ring, it is an end of segment
-						count := FillSliceFromMask(InputMbufs, &def[st].mask, OutputMbufs[0])
-						safeEnqueue(OUT[answers[0]], OutputMbufs[0], uint(count))
-						currentSpeed.Packets += uint64(count)
-					} else if cur.followingNumber == 1 {
-						// We have simple handle. Mask will remain the same, current function will be changed
-						def[st].f = cur.next[0]
-						st++
-					} else {
-						step := 0
-						currentMask = def[st].mask
-						for i := uint8(0); i < cur.followingNumber; i++ {
-							cont := asm.GenerateMask(&answers, &(vEach[i]), &currentMask, &def[st+step].mask)
-							if !cont {
-								def[st+step].f = cur.next[i]
-								step++
+				} else { // Vector code
+					packet.ExtractPackets(tempPackets, InputMbufs, n)
+					def[0].f = firstFunc
+					for i := uint(0); i < burstSize; i++ {
+						def[0].mask[i] = (i < n)
+					}
+					st := 0
+					for st != -1 {
+						cur := def[st].f
+						cur.vFunc(tempPackets, &def[st].mask, &answers, cur, context[cur.contextIndex])
+						if cur.followingNumber == 0 {
+							// We have constructSlice -> put packets inside ring, it is an end of segment
+							count := FillSliceFromMask(InputMbufs, &def[st].mask, OutputMbufs[0])
+							safeEnqueue(OUT[answers[0]][inIndex[q]], OutputMbufs[0], uint(count))
+							currentSpeed.Packets += uint64(count)
+						} else if cur.followingNumber == 1 {
+							// We have simple handle. Mask will remain the same, current function will be changed
+							def[st].f = cur.next[0]
+							st++
+						} else {
+							step := 0
+							currentMask = def[st].mask
+							for i := uint8(0); i < cur.followingNumber; i++ {
+								cont := asm.GenerateMask(&answers, &(vEach[i]), &currentMask, &def[st+step].mask)
+								if !cont {
+									def[st+step].f = cur.next[i]
+									step++
+								}
 							}
+							st += step
 						}
-						st += step
+						st--
 					}
-					st--
 				}
 			}
 		}
 	}
 }
 
-func recvRSS(parameters interface{}, flag *int32, coreID int) {
+func recvRSS(parameters interface{}, inIndex []int32, flag *int32, coreID int) {
 	srp := parameters.(*receiveParameters)
-	low.ReceiveRSS(uint16(srp.port.PortId), int16(srp.port.QueuesNumber-1), srp.out, flag, coreID)
+	low.ReceiveRSS(uint16(srp.port.PortId), inIndex, srp.out, flag, coreID)
 }
 
-func recvKNI(parameters interface{}, flag *int32, coreID int) {
+func recvKNI(parameters interface{}, inIndex []int32, flag *int32, coreID int) {
 	srp := parameters.(*receiveParameters)
-	low.ReceiveKNI(uint16(srp.port.PortId), srp.out, flag, coreID)
+	low.ReceiveKNI(uint16(srp.port.PortId), srp.out[0], flag, coreID)
 }
 
-func pGenerate(parameters interface{}, stopper [2]chan int, report chan reportPair, context []UserContext) {
+func pGenerate(parameters interface{}, inIndex []int32, stopper [2]chan int, report chan reportPair, context []UserContext) {
 	// Function is unclonable, report is always nil
 	gp := parameters.(*generateParameters)
 	OUT := gp.out
@@ -1101,12 +1134,12 @@ func pGenerate(parameters interface{}, stopper [2]chan int, report chan reportPa
 				common.LogFatal(common.Debug, err)
 			}
 			generateFunction(tempPacket, context[0])
-			safeEnqueueOne(OUT, tempPacket.ToUintptr())
+			safeEnqueueOne(OUT[0], tempPacket.ToUintptr())
 		}
 	}
 }
 
-func pFastGenerate(parameters interface{}, stopper [2]chan int, report chan reportPair, context []UserContext) {
+func pFastGenerate(parameters interface{}, inIndex []int32, stopper [2]chan int, report chan reportPair, context []UserContext) {
 	gp := parameters.(*generateParameters)
 	OUT := gp.out
 	generateFunction := gp.generateFunction
@@ -1137,6 +1170,7 @@ func pFastGenerate(parameters interface{}, stopper [2]chan int, report chan repo
 		default:
 			err := low.AllocateMbufs(bufs, mempool, burstSize)
 			if err != nil {
+				low.ReportMempoolsState()
 				common.LogFatal(common.Debug, err)
 			}
 			if vector == false {
@@ -1152,7 +1186,7 @@ func pFastGenerate(parameters interface{}, stopper [2]chan int, report chan repo
 				packet.ExtractPackets(tempPackets, bufs, burstSize)
 				vectorGenerateFunction(tempPackets, context[0])
 			}
-			safeEnqueue(OUT, bufs, burstSize)
+			safeEnqueue(OUT[0], bufs, burstSize)
 			currentSpeed.Packets += uint64(burstSize)
 			// GO parks goroutines while Sleep. So Sleep lasts more time than our precision
 			// we just want to slow goroutine down without parking, so loop is OK for this.
@@ -1167,7 +1201,7 @@ func pFastGenerate(parameters interface{}, stopper [2]chan int, report chan repo
 }
 
 // TODO reassembled packets are not supported
-func pcopy(parameters interface{}, stopper [2]chan int, report chan reportPair, context []UserContext) {
+func pcopy(parameters interface{}, inIndex []int32, stopper [2]chan int, report chan reportPair, context []UserContext) {
 	cp := parameters.(*copyParameters)
 	IN := cp.in
 	OUT := cp.out
@@ -1194,42 +1228,45 @@ func pcopy(parameters interface{}, stopper [2]chan int, report chan reportPair, 
 			report <- currentSpeed
 			currentSpeed = reportPair{}
 		default:
-			n := IN.DequeueBurst(bufs1, burstSize)
-			if n != 0 {
-				if err := low.AllocateMbufs(bufs2, mempool, n); err != nil {
-					common.LogFatal(common.Debug, err)
-				}
-				for i := uint(0); i < n; i++ {
-					// TODO Maybe we need to prefetcht here?
-					tempPacket1 = packet.ExtractPacket(bufs1[i])
-					tempPacket2 = packet.ExtractPacket(bufs2[i])
-					packet.GeneratePacketFromByte(tempPacket2, tempPacket1.GetRawPacketBytes())
-					if reportMbits {
-						currentSpeed.Bytes += uint64(tempPacket1.GetPacketLen())
+			for q := int32(1); q < inIndex[0]+1; q++ {
+				n := IN[inIndex[q]].DequeueBurst(bufs1, burstSize)
+				if n != 0 {
+					if err := low.AllocateMbufs(bufs2, mempool, n); err != nil {
+						common.LogFatal(common.Debug, err)
 					}
+					for i := uint(0); i < n; i++ {
+						// TODO Maybe we need to prefetcht here?
+						tempPacket1 = packet.ExtractPacket(bufs1[i])
+						tempPacket2 = packet.ExtractPacket(bufs2[i])
+						packet.GeneratePacketFromByte(tempPacket2, tempPacket1.GetRawPacketBytes())
+						if reportMbits {
+							currentSpeed.Bytes += uint64(tempPacket1.GetPacketLen())
+						}
+					}
+					safeEnqueue(OUT[inIndex[q]], bufs1, uint(n))
+					safeEnqueue(OUTCopy[inIndex[q]], bufs2, uint(n))
+					currentSpeed.Packets += uint64(n)
 				}
-				safeEnqueue(OUT, bufs1, uint(n))
-				safeEnqueue(OUTCopy, bufs2, uint(n))
-				currentSpeed.Packets += uint64(n)
-			}
-			// GO parks goroutines while Sleep. So Sleep lasts more time than our precision
-			// we just want to slow goroutine down without parking, so loop is OK for this.
-			// time.Now lasts approximately 70ns and this satisfies us
-			if pause != 0 {
-				a := time.Now()
-				for time.Since(a) < time.Duration(pause*int(burstSize))*time.Nanosecond {
+				// GO parks goroutines while Sleep. So Sleep lasts more time than our precision
+				// we just want to slow goroutine down without parking, so loop is OK for this.
+				// time.Now lasts approximately 70ns and this satisfies us
+				if pause != 0 {
+					// pause should be 0 only if function works with ONE inIndex
+					a := time.Now()
+					for time.Since(a) < time.Duration(pause*int(burstSize))*time.Nanosecond {
+					}
 				}
 			}
 		}
 	}
 }
 
-func send(parameters interface{}, flag *int32, coreID int) {
+func send(parameters interface{}, inIndex []int32, flag *int32, coreID int) {
 	srp := parameters.(*sendParameters)
-	low.Send(srp.port, srp.queue, srp.in, flag, coreID)
+	low.Send(srp.port, srp.queue, srp.in, inIndex[0], flag, coreID)
 }
 
-func merge(from, to *low.Ring) {
+func merge(from low.Rings, to low.Rings) {
 	// We should change out rings in all flow functions which we added before
 	// and change them to one "after merge" ring.
 	// We don't proceed stop and send functions here because they don't have
@@ -1239,22 +1276,22 @@ func merge(from, to *low.Ring) {
 	for i := range schedState.ff {
 		switch parameters := schedState.ff[i].Parameters.(type) {
 		case *receiveParameters:
-			if parameters.out == from {
+			if parameters.out[0] == from[0] {
 				parameters.out = to
 			}
 		case *generateParameters:
-			if parameters.out == from {
+			if parameters.out[0] == from[0] {
 				parameters.out = to
 			}
 		case *readParameters:
-			if parameters.out == from {
+			if parameters.out[0] == from[0] {
 				parameters.out = to
 			}
 		case *copyParameters:
-			if parameters.out == from {
+			if parameters.out[0] == from[0] {
 				parameters.out = to
 			}
-			if parameters.outCopy == from {
+			if parameters.outCopy[0] == from[0] {
 				parameters.outCopy = to
 			}
 		}
@@ -1322,7 +1359,7 @@ func vConstructSlice(packets []*packet.Packet, mask *[burstSize]bool, answers *[
 	answers[0] = uint8(ve.bufIndex)
 }
 
-func write(parameters interface{}, stopper [2]chan int) {
+func write(parameters interface{}, inIndex []int32, stopper [2]chan int) {
 	wp := parameters.(*writeParameters)
 	IN := wp.in
 	filename := wp.filename
@@ -1347,21 +1384,23 @@ func write(parameters interface{}, stopper [2]chan int) {
 			stopper[1] <- 1
 			return
 		default:
-			n := IN.DequeueBurst(bufIn, 1)
-			if n == 0 {
-				continue
+			for q := int32(0); q < inIndex[0]; q++ {
+				n := IN[q].DequeueBurst(bufIn, 1)
+				if n == 0 {
+					continue
+				}
+				tempPacket = packet.ExtractPacket(bufIn[0])
+				err := tempPacket.WritePcapOnePacket(f)
+				if err != nil {
+					common.LogFatal(common.Debug, err)
+				}
+				low.DirectStop(1, bufIn)
 			}
-			tempPacket = packet.ExtractPacket(bufIn[0])
-			err := tempPacket.WritePcapOnePacket(f)
-			if err != nil {
-				common.LogFatal(common.Debug, err)
-			}
-			low.DirectStop(1, bufIn)
 		}
 	}
 }
 
-func read(parameters interface{}, stopper [2]chan int) {
+func read(parameters interface{}, inIndex []int32, stopper [2]chan int) {
 	rp := parameters.(*readParameters)
 	OUT := rp.out
 	filename := rp.filename
@@ -1412,7 +1451,7 @@ func read(parameters interface{}, stopper [2]chan int) {
 			}
 			// TODO we need packet reassembly here. However we don't
 			// use mbuf packet_type here, so it is impossible.
-			safeEnqueueOne(OUT, tempPacket.ToUintptr())
+			safeEnqueueOne(OUT[0], tempPacket.ToUintptr())
 		}
 	}
 }
@@ -1424,7 +1463,7 @@ func safeEnqueue(place *low.Ring, data []uintptr, number uint) {
 	done := place.EnqueueBurst(data, number)
 	if done < number {
 		schedState.Dropped += number - uint(done)
-		done2 := schedState.StopRing.EnqueueBurst(data[done:number], number-uint(done))
+		done2 := schedState.StopRing[0].EnqueueBurst(data[done:number], number-uint(done))
 		// If stop ring is crowded a function will call C stop directly without
 		// moving forward. It prevents constant crowd stop and increases
 		// performance on "long accelerating" topologies in 1.5x times.

--- a/flow/scheduler.go
+++ b/flow/scheduler.go
@@ -55,6 +55,22 @@ type clonePair struct {
 	flag    int32
 }
 
+type instance struct {
+	inIndex []int32
+	// Clones of this instance
+	clone []*clonePair
+	// Channel for reporting current speed.
+	report       chan reportPair
+	currentSpeed reportPair
+	// Current saved speed when making a clone.
+	// It will be compared with immediate current speed to stop a clone.
+	previousSpeed []reportPair
+	// Number of clones of this instance
+	cloneNumber int
+	pause       int
+	ff          *flowFunction
+}
+
 // UserContext is used inside flow packet and is going for user via it
 type UserContext interface {
 	Copy() interface{}
@@ -62,9 +78,9 @@ type UserContext interface {
 }
 
 // Function types which are used inside flow functions
-type uncloneFlowFunction func(interface{}, [2]chan int)
-type cloneFlowFunction func(interface{}, [2]chan int, chan reportPair, []UserContext)
-type cFlowFunction func(interface{}, *int32, int)
+type uncloneFlowFunction func(interface{}, []int32, [2]chan int)
+type cloneFlowFunction func(interface{}, []int32, [2]chan int, chan reportPair, []UserContext)
+type cFlowFunction func(interface{}, []int32, *int32, int)
 
 type ffType int
 
@@ -87,29 +103,21 @@ type flowFunction struct {
 	cFunction cFlowFunction
 	// Main body of clonable flow function
 	cloneFunction cloneFlowFunction
-	// Number of clones of this function
-	cloneNumber int
-	// Clones of this function. They are determined
-	// by their core and their stopper channel
-	clone []*clonePair
-	// Channel for reporting current speed.
-	// It is one for all clones
-	report chan reportPair
-	// Current saved speed when making a clone.
-	// It will be compared with immediate current speed to stop a clone.
-	previousSpeed []reportPair
-	// For debug purposes
-	currentSpeed reportPair
+	// Number of instances of this function
+	instanceNumber int
+	// Instances of this function
+	instance     []*instance
+	oneCoreSpeed reportPair
 	// Name of flow function
-	name    string
-	context *[]UserContext
-	pause   int
-	fType   ffType
+	name          string
+	context       *[]UserContext
+	fType         ffType
+	inIndexNumber int32
 }
 
 // Adding every flow function to scheduler list
 func (scheduler *scheduler) addFF(name string, ucfn uncloneFlowFunction, Cfn cFlowFunction, cfn cloneFlowFunction,
-	par interface{}, context *[]UserContext, fType ffType) {
+	par interface{}, context *[]UserContext, fType ffType, inIndexNumber int32) {
 	ff := new(flowFunction)
 	nameC := 1
 	tName := name
@@ -124,10 +132,9 @@ func (scheduler *scheduler) addFF(name string, ucfn uncloneFlowFunction, Cfn cFl
 	ff.cFunction = Cfn
 	ff.cloneFunction = cfn
 	ff.Parameters = par
-	ff.report = make(chan reportPair, 50)
 	ff.context = context
-	ff.previousSpeed = make([]reportPair, len(scheduler.cores), len(scheduler.cores))
 	ff.fType = fType
+	ff.inIndexNumber = inIndexNumber
 	scheduler.ff = append(scheduler.ff, ff)
 }
 
@@ -136,8 +143,9 @@ type scheduler struct {
 	cores             []core
 	off               bool
 	offRemove         bool
+	anyway            bool
 	stopDedicatedCore bool
-	StopRing          *low.Ring
+	StopRing          low.Rings
 	usedCores         uint8
 	checkTime         uint
 	debugTime         uint
@@ -152,8 +160,8 @@ type core struct {
 	isfree bool
 }
 
-func newScheduler(cpus []int, schedulerOff bool, schedulerOffRemove bool,
-	stopDedicatedCore bool, stopRing *low.Ring, checkTime uint, debugTime uint, maxPacketsToClone uint32, maxRecv int) *scheduler {
+func newScheduler(cpus []int, schedulerOff bool, schedulerOffRemove bool, stopDedicatedCore bool,
+	stopRing low.Rings, checkTime uint, debugTime uint, maxPacketsToClone uint32, maxRecv int, anyway bool) *scheduler {
 	coresNumber := len(cpus)
 	// Init scheduler
 	scheduler := new(scheduler)
@@ -169,6 +177,7 @@ func newScheduler(cpus []int, schedulerOff bool, schedulerOffRemove bool,
 	scheduler.debugTime = debugTime
 	scheduler.maxPacketsToClone = maxPacketsToClone
 	scheduler.maxRecv = maxRecv
+	scheduler.anyway = anyway
 
 	return scheduler
 }
@@ -195,7 +204,7 @@ func (scheduler *scheduler) systemStart() (err error) {
 		low.Stop(scheduler.StopRing, &scheduler.stopFlag, core)
 	}()
 	for i := range scheduler.ff {
-		if err = scheduler.startFF(scheduler.ff[i]); err != nil {
+		if err = scheduler.ff[i].startNewInstance(constructNewIndex(scheduler.ff[i].inIndexNumber), scheduler); err != nil {
 			return err
 		}
 	}
@@ -204,17 +213,34 @@ func (scheduler *scheduler) systemStart() (err error) {
 	return nil
 }
 
-func (scheduler *scheduler) startFF(ff *flowFunction) (err error) {
+func (ff *flowFunction) startNewInstance(inIndex []int32, scheduler *scheduler) (err error) {
+	ffi := new(instance)
+	common.LogDebug(common.Initialization, "Start new instance for", ff.name)
+	ffi.inIndex = inIndex
+	ffi.report = make(chan reportPair, 50)
+	ffi.previousSpeed = make([]reportPair, len(scheduler.cores), len(scheduler.cores))
+	ffi.ff = ff
+	err = ffi.startNewClone(scheduler, ff.instanceNumber)
+	if err == nil {
+		ff.instance = append(ff.instance, ffi)
+		ff.instanceNumber++
+	}
+	return err
+}
+
+func (ffi *instance) startNewClone(scheduler *scheduler, n int) (err error) {
+	ff := ffi.ff
 	core, index, err := scheduler.getCore()
 	if err != nil {
+		common.LogWarning(common.Debug, "Can't start new clone for", ff.name, "instance", n)
 		return err
 	}
-	common.LogDebug(common.Initialization, "Start new FlowFunction or clone for", ff.name, "at", core, "core")
-	ff.clone = append(ff.clone, &clonePair{index, [2]chan int{nil, nil}, process})
-	ff.cloneNumber++
+	common.LogDebug(common.Initialization, "Start new clone for", ff.name, "instance", n, "at", core, "core")
+	ffi.clone = append(ffi.clone, &clonePair{index, [2]chan int{nil, nil}, process})
+	ffi.cloneNumber++
 	if ff.fType != receiveRSS && ff.fType != sendReceiveKNI {
-		ff.clone[ff.cloneNumber-1].channel[0] = make(chan int)
-		ff.clone[ff.cloneNumber-1].channel[1] = make(chan int)
+		ffi.clone[ffi.cloneNumber-1].channel[0] = make(chan int)
+		ffi.clone[ffi.cloneNumber-1].channel[1] = make(chan int)
 	}
 	go func() {
 		if ff.fType != receiveRSS && ff.fType != sendReceiveKNI {
@@ -222,32 +248,52 @@ func (scheduler *scheduler) startFF(ff *flowFunction) (err error) {
 				common.LogFatal(common.Initialization, "Failed to set affinity to", core, "core: ", err)
 			}
 			if ff.fType == segmentCopy || ff.fType == fastGenerate || ff.fType == generate {
-				ff.cloneFunction(ff.Parameters, ff.clone[ff.cloneNumber-1].channel, ff.report, cloneContext(ff.context))
+				ff.cloneFunction(ff.Parameters, ffi.inIndex, ffi.clone[ffi.cloneNumber-1].channel, ffi.report, cloneContext(ff.context))
 			} else {
-				ff.uncloneFunction(ff.Parameters, ff.clone[ff.cloneNumber-1].channel)
+				ff.uncloneFunction(ff.Parameters, ffi.inIndex, ffi.clone[ffi.cloneNumber-1].channel)
 			}
 		} else {
-			ff.cFunction(ff.Parameters, &ff.clone[ff.cloneNumber-1].flag, core)
+			ff.cFunction(ff.Parameters, ffi.inIndex, &ffi.clone[ffi.cloneNumber-1].flag, core)
 		}
 	}()
 	return nil
 }
 
-func (scheduler *scheduler) stopFF(ff *flowFunction) {
-	if ff.clone[ff.cloneNumber-1].channel[0] != nil {
-		ff.clone[ff.cloneNumber-1].channel[0] <- -1
-		<-ff.clone[ff.cloneNumber-1].channel[1]
-		close(ff.clone[ff.cloneNumber-1].channel[0])
-		close(ff.clone[ff.cloneNumber-1].channel[1])
+func (ff *flowFunction) stopClone(ffi *instance, scheduler *scheduler) {
+	if ffi.clone[ffi.cloneNumber-1].channel[0] != nil {
+		ffi.clone[ffi.cloneNumber-1].channel[0] <- -1
+		<-ffi.clone[ffi.cloneNumber-1].channel[1]
+		close(ffi.clone[ffi.cloneNumber-1].channel[0])
+		close(ffi.clone[ffi.cloneNumber-1].channel[1])
 	} else {
-		atomic.StoreInt32(&ff.clone[ff.cloneNumber-1].flag, stopRequest)
-		for atomic.LoadInt32(&ff.clone[ff.cloneNumber-1].flag) != wasStopped {
+		atomic.StoreInt32(&ffi.clone[ffi.cloneNumber-1].flag, stopRequest)
+		for atomic.LoadInt32(&ffi.clone[ffi.cloneNumber-1].flag) != wasStopped {
 			runtime.Gosched()
 		}
 	}
-	scheduler.setCoreByIndex(ff.clone[ff.cloneNumber-1].index)
-	ff.clone = ff.clone[:len(ff.clone)-1]
-	ff.cloneNumber--
+	scheduler.setCoreByIndex(ffi.clone[ffi.cloneNumber-1].index)
+	ffi.clone = ffi.clone[:len(ffi.clone)-1]
+	ffi.cloneNumber--
+}
+
+func (ff *flowFunction) stopInstance(from int, to int, scheduler *scheduler) {
+	common.LogDebug(common.Initialization, "Stop instance for", ff.name)
+	fromInstance := ff.instance[from]
+	for fromInstance.cloneNumber != 0 {
+		ff.stopClone(fromInstance, scheduler)
+	}
+	if fromInstance.report != nil {
+		close(fromInstance.report)
+	}
+	if to != -1 {
+		toInstance := ff.instance[to]
+		for q := int32(0); q < fromInstance.inIndex[0]; q++ {
+			toInstance.inIndex[toInstance.inIndex[0]+q+1] = fromInstance.inIndex[q+1]
+		}
+		toInstance.inIndex[0] += fromInstance.inIndex[0]
+		ff.instance = append(ff.instance[:from], ff.instance[from+1:]...)
+	}
+	ff.instanceNumber--
 }
 
 func (scheduler *scheduler) systemStop() {
@@ -257,11 +303,8 @@ func (scheduler *scheduler) systemStop() {
 		runtime.Gosched()
 	}
 	for i := range scheduler.ff {
-		for scheduler.ff[i].cloneNumber != 0 {
-			scheduler.stopFF(scheduler.ff[i])
-		}
-		if scheduler.ff[i].report != nil {
-			close(scheduler.ff[i].report)
+		for scheduler.ff[i].instanceNumber != 0 {
+			scheduler.ff[i].stopInstance(0, -1, scheduler)
 		}
 	}
 	scheduler.setCoreByIndex(0) // scheduler
@@ -307,46 +350,85 @@ func (scheduler *scheduler) schedule(schedTime uint) {
 			// Firstly we check removing clones. We can remove one clone if:
 			// 1. flow function has clones or it is fastGenerate
 			// 2. scheduler removing is switched on
-			if (ff.cloneNumber > 1 || ff.fType == fastGenerate) && (scheduler.offRemove == false) {
+			if scheduler.offRemove == false {
 				switch ff.fType {
-				case segmentCopy:
-					// 3. current speed of flow function is lower, than saved speed with less number of clones
-					if ff.currentSpeed.Packets < ff.previousSpeed[ff.cloneNumber-1].Packets {
-						// Save current speed as speed of flow function with this number of clones before removing
-						ff.previousSpeed[ff.cloneNumber] = ff.currentSpeed
-						scheduler.stopFF(ff)
-						ff.updatePause(ff.cloneNumber)
-						// After removing a clone we don't want to try to add clone immediately
-						continue
-					}
-				case fastGenerate:
-					targetSpeed := (ff.Parameters.(*generateParameters)).targetSpeed
-					speedPKTS := float64(ff.currentSpeed.normalize(schedTime).Packets)
-					// 3. Current speed is much bigger than target speed
-					if speedPKTS > 1.1*targetSpeed {
-						// 4. TODO strange heuristic, it is required to check this
-						if ff.cloneNumber > 1 && targetSpeed/float64(ff.cloneNumber+1)*float64(ff.cloneNumber) > speedPKTS {
-							scheduler.stopFF(ff)
-							ff.updatePause(0)
-							continue
-						} else {
-							if ff.pause == 0 {
-								// This is proportion between required and current speeds.
-								// 1000000000 is converting to nanoseconds
-								ff.updatePause(int((speedPKTS - targetSpeed) / speedPKTS / targetSpeed * 1000000000))
-							} else if float64(ff.pause)*generatePauseStep < 2 {
-								// Multiplying can't be used here due to integer truncation
-								ff.updatePause(ff.pause + 3)
-							} else {
-								ff.updatePause(int((1 + generatePauseStep) * float64(ff.pause)))
+				case segmentCopy: // Both instances and clones
+					for q := 0; q < ff.instanceNumber; q++ {
+						ffi := ff.instance[q]
+						if ffi.cloneNumber > 1 {
+							// 3. current speed of flow function is lower, than saved speed with less number of clones
+							if ffi.currentSpeed.Packets < ffi.previousSpeed[ffi.cloneNumber-1].Packets {
+								// Save current speed as speed of flow function with this number of clones before removing
+								ffi.previousSpeed[ffi.cloneNumber] = ffi.currentSpeed
+								ff.stopClone(ffi, scheduler)
+								ffi.updatePause(ffi.cloneNumber)
 							}
 						}
 					}
-				case receiveRSS:
-					if low.CheckRSSPacketCount(ff.Parameters.(*receiveParameters).port) < RSSCloneMin {
-						scheduler.stopFF(ff)
-						low.DecreaseRSS((ff.Parameters.(*receiveParameters)).port)
-						continue
+					if ff.instanceNumber > 1 {
+						min0 := 0
+						min1 := 1
+						if ff.instance[0].currentSpeed.Packets > ff.instance[1].currentSpeed.Packets {
+							min0 = 1
+							min1 = 0
+						}
+						for q := 2; q < ff.instanceNumber; q++ {
+							if ff.instance[q].currentSpeed.Packets < ff.instance[min0].currentSpeed.Packets {
+								min1 = min0
+								min0 = q
+								continue
+							}
+							if ff.instance[q].currentSpeed.Packets < ff.instance[min1].currentSpeed.Packets {
+								min1 = q
+							}
+						}
+						if ff.instance[min0].currentSpeed.Packets+ff.instance[min1].currentSpeed.Packets < ff.oneCoreSpeed.Packets {
+							ff.stopInstance(min0, min1, scheduler)
+						}
+					}
+				case fastGenerate: // Only clones, no instances
+					targetSpeed := (ff.Parameters.(*generateParameters)).targetSpeed
+					speedPKTS := float64(ff.instance[0].currentSpeed.normalize(schedTime).Packets)
+					// 3. Current speed is much bigger than target speed
+					if speedPKTS > 1.1*targetSpeed {
+						ffi := ff.instance[0]
+						// 4. TODO strange heuristic, it is required to check this
+						if ffi.cloneNumber > 1 && targetSpeed/float64(ffi.cloneNumber+1)*float64(ffi.cloneNumber) > speedPKTS {
+							ff.stopClone(ffi, scheduler)
+							ffi.updatePause(0)
+							continue
+						} else {
+							if ffi.pause == 0 {
+								// This is proportion between required and current speeds.
+								// 1000000000 is converting to nanoseconds
+								ffi.updatePause(int((speedPKTS - targetSpeed) / speedPKTS / targetSpeed * 1000000000))
+							} else if float64(ffi.pause)*generatePauseStep < 2 {
+								// Multiplying can't be used here due to integer truncation
+								ffi.updatePause(ffi.pause + 3)
+							} else {
+								ffi.updatePause(int((1 + generatePauseStep) * float64(ffi.pause)))
+							}
+						}
+					}
+				case receiveRSS: // Only instances, no clones
+					if ff.instanceNumber > 1 {
+						first := -1
+						for q := 0; q < ff.instanceNumber; q++ {
+							var q1 int32
+							for q1 = 1; q1 < ff.instance[q].inIndex[0]+1; q1++ {
+								if low.CheckRSSPacketCount(ff.Parameters.(*receiveParameters).port, int16(ff.instance[q].inIndex[q1])) > RSSCloneMin {
+									break
+								}
+							}
+							if q1 == ff.instance[q].inIndex[0]+1 {
+								if first == -1 {
+									first = q
+								} else {
+									ff.stopInstance(first, q, scheduler)
+									break
+								}
+							}
+						}
 					}
 				case readWrite, generate, sendReceiveKNI:
 				}
@@ -354,55 +436,74 @@ func (scheduler *scheduler) schedule(schedTime uint) {
 			// Secondly we check adding clones. We can add one clone if:
 			// 1. scheduler is switched on
 			// 2. ouput ring is quite empty
-			if scheduler.off == false && ff.checkOutputRingClonable(scheduler.maxPacketsToClone) {
+			if scheduler.off == false {
 				switch ff.fType {
-				case segmentCopy:
-					// 3. check function signals that we need to clone
-					// 4. we don't know flow function speed with more clones, or we know it and it is bigger than current speed
-					if ff.checkInputRingClonable(scheduler.maxPacketsToClone) &&
-						(ff.previousSpeed[ff.cloneNumber+1].Packets == 0 || ff.previousSpeed[ff.cloneNumber+1].Packets > ff.currentSpeed.Packets) {
-						// Save current speed as speed of flow function with this number of clones before adding
-						ff.previousSpeed[ff.cloneNumber] = ff.currentSpeed
-						if scheduler.startFF(ff) == nil {
-							// Add a pause to all clones. This pause depends on the number of clones.
-							ff.updatePause(ff.cloneNumber)
-						} else {
-							common.LogWarning(common.Debug, "Can't start new clone for", ff.name)
+				case segmentCopy: // Both instances and clones
+					l := ff.instanceNumber
+					a := true
+					for q := 0; q < l; q++ {
+						ffi := ff.instance[q]
+						if ffi.checkInputRingClonable(scheduler.maxPacketsToClone) {
+							if ffi.inIndex[0] > 1 {
+								ff.oneCoreSpeed = ffi.currentSpeed
+								if ff.startNewInstance(constructZeroIndex(ffi.inIndex), scheduler) == nil {
+									ff.instance[ff.instanceNumber-1].inIndex = constructDuplicatedIndex(ffi.inIndex)
+									a = false
+								}
+							}
 						}
-						continue
 					}
-					// Scheduler can't add new clones if saved flow function speed with more
-					// clones is slower than current. However this speed can be changed due to
-					// external reasons. So flow function should check and update this speed
-					// regular time.
-					if checkRequired == true {
-						// Regular flow function speed check after each checkTime milliseconds,
-						// it is done by erasing previously measured speed data. After this scheduler can
-						// add new clone. If performance decreases with added clone, it will be stopped
-						// with setting speed data.
-						ff.previousSpeed[ff.cloneNumber+1].Packets = 0
+					if a == true {
+						for q := 0; q < l; q++ {
+							ffi := ff.instance[q]
+							if ffi.checkInputRingClonable(scheduler.maxPacketsToClone) {
+								if ffi.inIndex[0] == 1 && scheduler.anyway && ffi.checkOutputRingClonable(scheduler.maxPacketsToClone) &&
+									(ffi.previousSpeed[ffi.cloneNumber+1].Packets == 0 ||
+										ffi.previousSpeed[ffi.cloneNumber+1].Packets > ffi.currentSpeed.Packets) {
+									// Save current speed as speed of flow function with this number of clones before adding
+									ffi.previousSpeed[ffi.cloneNumber] = ffi.currentSpeed
+									if ffi.startNewClone(scheduler, q) == nil {
+										// Add a pause to all clones. This pause depends on the number of clones.
+										ffi.updatePause(ffi.cloneNumber)
+									}
+									continue
+								}
+							}
+							// Scheduler can't add new clones if saved flow function speed with more
+							// clones is slower than current. However this speed can be changed due to
+							// external reasons. So flow function should check and update this speed
+							// regular time.
+							if checkRequired == true {
+								// Regular flow function speed check after each checkTime milliseconds,
+								// it is done by erasing previously measured speed data. After this scheduler can
+								// add new clone. If performance decreases with added clone, it will be stopped
+								// with setting speed data.
+								ffi.previousSpeed[ffi.cloneNumber+1].Packets = 0
+							}
+						}
 					}
-				case fastGenerate:
+				case fastGenerate: // Only clones, no instances
 					// 3. speed is not enough
-					if float64(ff.currentSpeed.normalize(schedTime).Packets) < (ff.Parameters.(*generateParameters)).targetSpeed {
-						if ff.pause != 0 {
-							ff.updatePause(int((1 - generatePauseStep) * float64(ff.pause)))
-						} else {
+					if float64(ff.instance[0].currentSpeed.normalize(schedTime).Packets) < (ff.Parameters.(*generateParameters)).targetSpeed {
+						if ff.instance[0].pause != 0 {
+							ff.instance[0].updatePause(int((1 - generatePauseStep) * float64(ff.instance[0].pause)))
+						} else if ff.instance[0].checkOutputRingClonable(scheduler.maxPacketsToClone) {
 							// 3. there is no pause
-							if scheduler.startFF(ff) == nil {
-								ff.updatePause(0)
-							} else {
-								common.LogWarning(common.Debug, "Can't start new clone for", ff.name)
+							if ff.instance[0].startNewClone(scheduler, 0) == nil {
+								ff.instance[0].updatePause(0)
 							}
 							continue
 						}
 					}
-				case receiveRSS:
+				case receiveRSS: // Only instances, no clones
 					// 3. Number of packets in RSS is big enogh to cause overwrite (drop) problems
-					if ff.checkInputRingClonable(RSSCloneMax) && ff.cloneNumber < scheduler.maxRecv {
-						if low.IncreaseRSS((ff.Parameters.(*receiveParameters)).port) {
-							if scheduler.startFF(ff) != nil {
-								common.LogWarning(common.Debug, "Can't start new clone for", ff.name)
+					if ff.instanceNumber < scheduler.maxRecv && ff.inIndexNumber > 1 {
+						for q := 0; q < ff.instanceNumber; q++ {
+							if ff.instance[q].checkInputRingClonable(RSSCloneMax) && ff.instance[q].checkOutputRingClonable(scheduler.maxPacketsToClone) {
+								if ff.startNewInstance(constructZeroIndex(ff.instance[q].inIndex), scheduler) == nil {
+									ff.instance[ff.instanceNumber-1].inIndex = constructDuplicatedIndex(ff.instance[q].inIndex)
+								}
+								break
 							}
 						}
 					}
@@ -429,25 +530,27 @@ func cloneContext(ctx *[]UserContext) []UserContext {
 	return ret
 }
 
-func (ff *flowFunction) updatePause(pause int) {
-	ff.pause = pause
-	for j := 0; j < ff.cloneNumber; j++ {
-		ff.clone[j].channel[0] <- ff.pause
+func (ffi *instance) updatePause(pause int) {
+	ffi.pause = pause
+	for j := 0; j < ffi.cloneNumber; j++ {
+		ffi.clone[j].channel[0] <- ffi.pause
 	}
 }
 
 func (ff *flowFunction) printDebug(schedTime uint) {
 	switch ff.fType {
 	case segmentCopy:
-		out := ff.currentSpeed.normalize(schedTime)
-		if reportMbits {
-			common.LogDebug(common.Debug, "Current speed of", ff.name, "is", out.Packets, "PKT/S,", out.Bytes, "Mbits/s")
-		} else {
-			common.LogDebug(common.Debug, "Current speed of", ff.name, "is", out.Packets, "PKT/S")
+		for q := 0; q < ff.instanceNumber; q++ {
+			out := ff.instance[q].currentSpeed.normalize(schedTime)
+			if reportMbits {
+				common.LogDebug(common.Debug, "Current speed of", q, "instance of", ff.name, "is", out.Packets, "PKT/S,", out.Bytes, "Mbits/s")
+			} else {
+				common.LogDebug(common.Debug, "Current speed of", q, "instance of", ff.name, "is", out.Packets, "PKT/S, cloneNumber:", ff.instance[q].cloneNumber)
+			}
 		}
 	case fastGenerate:
 		targetSpeed := (ff.Parameters.(*generateParameters)).targetSpeed
-		out := ff.currentSpeed.normalize(schedTime)
+		out := ff.instance[0].currentSpeed.normalize(schedTime)
 		if reportMbits {
 			common.LogDebug(common.Debug, "Current speed of", ff.name, "is", out.Packets, "PKT/S,", out.Bytes, "Mbits/s, target speed is", int64(targetSpeed), "PKT/S")
 		} else {
@@ -468,15 +571,18 @@ func (current reportPair) normalize(schedTime uint) reportPair {
 func (ff *flowFunction) updateCurrentSpeed() {
 	// Gather and sum current speeds from all clones of current flow function
 	// Flow function itself and all clones put their speeds in one channel
-	ff.currentSpeed = reportPair{}
-	t := len(ff.report) - ff.cloneNumber
-	for k := 0; k < t; k++ {
-		<-ff.report
-	}
-	for k := 0; k < ff.cloneNumber; k++ {
-		temp := <-ff.report
-		ff.currentSpeed.Packets += temp.Packets
-		ff.currentSpeed.Bytes += temp.Bytes
+	for q := 0; q < ff.instanceNumber; q++ {
+		ffi := ff.instance[q]
+		ffi.currentSpeed = reportPair{}
+		t := len(ffi.report) - ffi.cloneNumber
+		for k := 0; k < t; k++ {
+			<-ffi.report
+		}
+		for k := 0; k < ffi.cloneNumber; k++ {
+			temp := <-ffi.report
+			ffi.currentSpeed.Packets += temp.Packets
+			ffi.currentSpeed.Bytes += temp.Bytes
+		}
 	}
 }
 
@@ -496,46 +602,86 @@ func (scheduler *scheduler) getCore() (int, int, error) {
 	return 0, 0, common.WrapWithNFError(nil, "Requested number of cores isn't enough.", common.NotEnoughCores)
 }
 
-func (ff *flowFunction) checkInputRingClonable(min uint32) bool {
-	switch ff.Parameters.(type) {
+func (ffi *instance) checkInputRingClonable(min uint32) bool {
+	switch ffi.ff.Parameters.(type) {
 	case *segmentParameters:
-		if ff.Parameters.(*segmentParameters).in.GetRingCount() > min {
-			return true
+		for q := int32(0); q < ffi.inIndex[0]; q++ {
+			if ffi.ff.Parameters.(*segmentParameters).in[ffi.inIndex[q+1]].GetRingCount() > min {
+				return true
+			}
 		}
 	case *copyParameters:
-		if ff.Parameters.(*copyParameters).in.GetRingCount() > min {
-			return true
+		for q := int32(0); q < ffi.inIndex[0]; q++ {
+			if ffi.ff.Parameters.(*copyParameters).in[ffi.inIndex[q+1]].GetRingCount() > min {
+				return true
+			}
 		}
 	case *receiveParameters:
-		if low.CheckRSSPacketCount(ff.Parameters.(*receiveParameters).port) > min {
-			return true
-		}
-	}
-	return false
-}
-
-func (ff *flowFunction) checkOutputRingClonable(max uint32) bool {
-	switch ff.Parameters.(type) {
-	case *receiveParameters:
-		if ff.Parameters.(*receiveParameters).out.GetRingCount() <= max {
-			return true
-		}
-	case *generateParameters:
-		if ff.Parameters.(*generateParameters).out.GetRingCount() <= max {
-			return true
-		}
-	case *copyParameters:
-		if ff.Parameters.(*copyParameters).out.GetRingCount() <= max ||
-			ff.Parameters.(*copyParameters).outCopy.GetRingCount() <= max {
-			return true
-		}
-	case *segmentParameters:
-		p := *(ff.Parameters.(*segmentParameters).out)
-		for i := range p {
-			if p[i].GetRingCount() <= max {
+		for q := int32(0); q < ffi.inIndex[0]; q++ {
+			if low.CheckRSSPacketCount(ffi.ff.Parameters.(*receiveParameters).port, int16(ffi.inIndex[q+1])) > min {
 				return true
 			}
 		}
 	}
 	return false
+}
+
+func (ffi *instance) checkOutputRingClonable(max uint32) bool {
+	switch ffi.ff.Parameters.(type) {
+	case *generateParameters:
+		if ffi.ff.Parameters.(*generateParameters).out[0].GetRingCount() <= max {
+			return true
+		}
+	case *receiveParameters:
+		for q := int32(0); q < ffi.inIndex[0]; q++ {
+			if ffi.ff.Parameters.(*receiveParameters).out[ffi.inIndex[q+1]].GetRingCount() <= max {
+				return true
+			}
+		}
+	case *copyParameters:
+		for q := int32(0); q < ffi.inIndex[0]; q++ {
+			if ffi.ff.Parameters.(*copyParameters).out[ffi.inIndex[q+1]].GetRingCount() <= max ||
+				ffi.ff.Parameters.(*copyParameters).outCopy[ffi.inIndex[q+1]].GetRingCount() <= max {
+				return true
+			}
+		}
+	case *segmentParameters:
+		p := *(ffi.ff.Parameters.(*segmentParameters).out)
+		for i := range p {
+			for q := int32(0); q < ffi.inIndex[0]; q++ {
+				if p[i][ffi.inIndex[q+1]].GetRingCount() <= max {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+func constructZeroIndex(old []int32) []int32 {
+	return make([]int32, len(old), len(old))
+}
+
+func constructDuplicatedIndex(old []int32) []int32 {
+	newIndex := make([]int32, len(old), len(old))
+	oldLen := old[0]/2 + old[0]%2
+	newLen := old[0] / 2
+	for q := int32(0); q < newLen; q++ {
+		newIndex[q+1] = old[q+1+oldLen]
+	}
+	newIndex[0] = newLen
+	old[0] = oldLen
+	return newIndex
+}
+
+func constructNewIndex(inIndexNumber int32) []int32 {
+	if inIndexNumber == 0 {
+		return nil
+	}
+	newIndex := make([]int32, inIndexNumber+1, inIndexNumber+1)
+	for q := int32(0); q < inIndexNumber; q++ {
+		newIndex[q+1] = q
+	}
+	newIndex[0] = inIndexNumber
+	return newIndex
 }


### PR DESCRIPTION
Now all flows have flexible number of intermediate rings which
depends on RSS queues number. Packets for same sessions
follow exact same routes.

Scheduler now has one more notion - flow function instance (ffi),
main concepts of new scheduler are:
1) Flow Function - covering structure, includes name,
working function, parameters, user contexts and other general information.
Different flow functions are completely different and can't be compared to each other.
2) Flow function instance - structure for working at different RSS flows.
Contains determination of current RSS flow.
Instances of one flow function are absolutely independent:
different cores, mempools, input/output rings and handled sessions.
3) Instance clone - structure for one process that is done useful work.
Contains determination of core and start/stop/report flags/channels.
Clones of one instance work at different cores. However they are not independent:
They share input/output rings, high level protocol sessions and lines in various tables.

Added new user options:
RestrictedCloning - forbids scheduler to add more that one clone per instance which can result to reordering
MaxInIndex - limits instance number per flow function. Can various from 1 to RSS restriction

Changed constants:
As now we have one mempool per each instance we limit default size:
mempool - 8191 instead of 4*8191
ring - 64 * burstSize instead of 256 * burstSize

Details:
Each flow has constant number of parallel rings.
Flows which started with receive have MaxInIndex parallel rings
Other flows like KNI, generate, PCAP read have 1 parallel ring
Merge will merge parallel rings by their numbers:
flows with 1 and 16 rings will merge as first to first ring
Basicaly all functions have one instance and one clone. This instance
handles all input parallel rings. If some function can't handle input flow
scheduler will add additional instance and divide input parallel rings
like half and half. If there is only on input ring and instance still
can't handle it scheduler will add clones (if this is permitted by user).

Pluses:
No reordering, flow locality
No locks for the same lines per session in any intermediate tables
Can reassemble high level protocols like TCP or HTML
Faster scheduler (working independently with each instance)

Minuses:
Memory usage for additional mempools and rings.
More cores due to increasing number of cores for "tails" from 1 to number of instances.