### PR TITLE
Core scheduler changes

### DIFF
--- a/flow/flow.go
+++ b/flow/flow.go
@@ -1009,7 +1009,7 @@ func segmentProcess(parameters interface{}, inIndex []int32, stopper [2]chan int
 		OutputMbufs[index] = make([]uintptr, burstSize)
 		countOfPackets[index] = 0
 	}
-	var currentSpeed reportPair
+	var currentState reportPair
 	var pause int
 	firstFunc := lp.firstFunc
 	// For scalar part
@@ -1043,11 +1043,11 @@ func segmentProcess(parameters interface{}, inIndex []int32, stopper [2]chan int
 				// For any events with this function we should restart timer
 				// We don't do it regularly without any events due to performance
 				tick = time.NewTicker(time.Duration(schedTime) * time.Millisecond)
-				currentSpeed = reportPair{}
+				currentState = reportPair{}
 			}
 		case <-tick.C:
-			report <- currentSpeed
-			currentSpeed = reportPair{}
+			report <- currentState
+			currentState = reportPair{}
 		default:
 			for q := int32(1); q < inIndex[0]+1; q++ {
 				n := IN[inIndex[q]].DequeueBurst(InputMbufs, burstSize)
@@ -1061,6 +1061,7 @@ func segmentProcess(parameters interface{}, inIndex []int32, stopper [2]chan int
 						for time.Since(a) < time.Duration(pause*int(burstSize))*time.Nanosecond {
 						}
 					}
+					currentState.ZeroAttempts[q-1]++
 					continue
 				}
 				if scalar { // Scalar code
@@ -1074,7 +1075,7 @@ func segmentProcess(parameters interface{}, inIndex []int32, stopper [2]chan int
 								OutputMbufs[nextIndex][countOfPackets[nextIndex]] = InputMbufs[i]
 								countOfPackets[nextIndex]++
 								if reportMbits {
-									currentSpeed.Bytes += uint64(tempPacket.GetPacketLen())
+									currentState.V.Bytes += uint64(tempPacket.GetPacketLen())
 								}
 								break
 							}
@@ -1086,7 +1087,7 @@ func segmentProcess(parameters interface{}, inIndex []int32, stopper [2]chan int
 							continue
 						}
 						safeEnqueue(OUT[index][inIndex[q]], OutputMbufs[index], uint(countOfPackets[index]))
-						currentSpeed.Packets += uint64(countOfPackets[index])
+						currentState.V.Packets += uint64(countOfPackets[index])
 						countOfPackets[index] = 0
 					}
 				} else { // Vector code
@@ -1103,7 +1104,7 @@ func segmentProcess(parameters interface{}, inIndex []int32, stopper [2]chan int
 							// We have constructSlice -> put packets inside ring, it is an end of segment
 							count := FillSliceFromMask(InputMbufs, &def[st].mask, OutputMbufs[0])
 							safeEnqueue(OUT[answers[0]][inIndex[q]], OutputMbufs[0], uint(count))
-							currentSpeed.Packets += uint64(count)
+							currentState.V.Packets += uint64(count)
 						} else if cur.followingNumber == 1 {
 							// We have simple handle. Mask will remain the same, current function will be changed
 							def[st].f = cur.next[0]
@@ -1175,7 +1176,7 @@ func pFastGenerate(parameters interface{}, inIndex []int32, stopper [2]chan int,
 	bufs := make([]uintptr, burstSize)
 	var tempPacket *packet.Packet
 	tempPackets := make([]*packet.Packet, burstSize)
-	var currentSpeed reportPair
+	var currentState reportPair
 	var pause int
 	tick := time.NewTicker(time.Duration(schedTime) * time.Millisecond)
 	stopper[1] <- 2 // Answer that function is ready
@@ -1194,11 +1195,11 @@ func pFastGenerate(parameters interface{}, inIndex []int32, stopper [2]chan int,
 				// For any events with this function we should restart timer
 				// We don't do it regularly without any events due to performance
 				tick = time.NewTicker(time.Duration(schedTime) * time.Millisecond)
-				currentSpeed = reportPair{}
+				currentState = reportPair{}
 			}
 		case <-tick.C:
-			report <- currentSpeed
-			currentSpeed = reportPair{}
+			report <- currentState
+			currentState = reportPair{}
 		default:
 			err := low.AllocateMbufs(bufs, mempool, burstSize)
 			if err != nil {
@@ -1211,7 +1212,7 @@ func pFastGenerate(parameters interface{}, inIndex []int32, stopper [2]chan int,
 					tempPacket = packet.ExtractPacket(bufs[i])
 					generateFunction(tempPacket, context[0])
 					if reportMbits {
-						currentSpeed.Bytes += uint64(tempPacket.GetPacketLen())
+						currentState.V.Bytes += uint64(tempPacket.GetPacketLen())
 					}
 				}
 			} else {
@@ -1219,7 +1220,7 @@ func pFastGenerate(parameters interface{}, inIndex []int32, stopper [2]chan int,
 				vectorGenerateFunction(tempPackets, context[0])
 			}
 			safeEnqueue(OUT[0], bufs, burstSize)
-			currentSpeed.Packets += uint64(burstSize)
+			currentState.V.Packets += uint64(burstSize)
 			// GO parks goroutines while Sleep. So Sleep lasts more time than our precision
 			// we just want to slow goroutine down without parking, so loop is OK for this.
 			// time.Now lasts approximately 70ns and this satisfies us
@@ -1244,7 +1245,7 @@ func pcopy(parameters interface{}, inIndex []int32, stopper [2]chan int, report 
 	bufs2 := make([]uintptr, burstSize)
 	var tempPacket1 *packet.Packet
 	var tempPacket2 *packet.Packet
-	var currentSpeed reportPair
+	var currentState reportPair
 	var pause int
 	tick := time.NewTicker(time.Duration(schedTime) * time.Millisecond)
 	stopper[1] <- 2 // Answer that function is ready
@@ -1261,11 +1262,11 @@ func pcopy(parameters interface{}, inIndex []int32, stopper [2]chan int, report 
 				// For any events with this function we should restart timer
 				// We don't do it regularly without any events due to performance
 				tick = time.NewTicker(time.Duration(schedTime) * time.Millisecond)
-				currentSpeed = reportPair{}
+				currentState = reportPair{}
 			}
 		case <-tick.C:
-			report <- currentSpeed
-			currentSpeed = reportPair{}
+			report <- currentState
+			currentState = reportPair{}
 		default:
 			for q := int32(1); q < inIndex[0]+1; q++ {
 				n := IN[inIndex[q]].DequeueBurst(bufs1, burstSize)
@@ -1279,17 +1280,18 @@ func pcopy(parameters interface{}, inIndex []int32, stopper [2]chan int, report 
 						tempPacket2 = packet.ExtractPacket(bufs2[i])
 						packet.GeneratePacketFromByte(tempPacket2, tempPacket1.GetRawPacketBytes())
 						if reportMbits {
-							currentSpeed.Bytes += uint64(tempPacket1.GetPacketLen())
+							currentState.V.Bytes += uint64(tempPacket1.GetPacketLen())
 						}
 					}
 					safeEnqueue(OUT[inIndex[q]], bufs1, uint(n))
 					safeEnqueue(OUTCopy[inIndex[q]], bufs2, uint(n))
-					currentSpeed.Packets += uint64(n)
+					currentState.V.Packets += uint64(n)
 				}
 				// GO parks goroutines while Sleep. So Sleep lasts more time than our precision
 				// we just want to slow goroutine down without parking, so loop is OK for this.
 				// time.Now lasts approximately 70ns and this satisfies us
 				if pause != 0 {
+					currentState.ZeroAttempts[q-1]++
 					// pause should be non 0 only if function works with ONE inIndex
 					a := time.Now()
 					for time.Since(a) < time.Duration(pause*int(burstSize))*time.Nanosecond {


### PR DESCRIPTION
Before
Reported from handler:
- current speed
Was used in heuristics:
- clone removing:    as vector of speeds for all number of clones, removed clone is current is less than saved
                     really unstable heuristic
- clone adding:      as speed for +1 clone. Do not add clone if saved increased speed is less than current
- instance removing: usage was wrong
- instance adding:   no usage

After
Reported from handler:
- current speed
Is used in heuristics:
- clone removing:    as "decreased speed". If current speed right after addition is less than saved - remove
- clone adding:      as "increased speed" in above - no changes
+
Reported from handler:
- current number of zero attempts to get packets from input ring
Is used in heuristics:
- clone removing:    if "summ of all zero attempts" * "time per attempt (previously calculated)" > "schedtime" - remove
- instance removing: 1) get number of zero attempts from the ring with less number of them at each instance
                     2) convert this number to time by multiplying each instance number to corresponding time per attempt
                     3) get two instances with the biggest times
                     4) if summ of thier times is bigger than schedTime - combine them at one core
Logic for removing is the following. Each core has useful time and vacant time.
Vacant time is determined as time for zero attempts. If summ of vacant times of two cores is more than summ of their
usefull times then one core will be able to handle tasks of both cores. They can be combined.
We need to measure "time per attempT" before using it - it is quite flexible.