### PR TITLE
Fixed overflow bug

### DIFF
--- a/flow/scheduler.go
+++ b/flow/scheduler.go
@@ -688,7 +688,7 @@ func (ffi *instance) checkInputRingClonable(min uint32) bool {
 		}
 	case *receiveParameters:
 		for q := int32(0); q < ffi.inIndex[0]; q++ {
-			if low.CheckRSSPacketCount(ffi.ff.Parameters.(*receiveParameters).port, int16(ffi.inIndex[q+1])) > min {
+			if low.CheckRSSPacketCount(ffi.ff.Parameters.(*receiveParameters).port, int16(ffi.inIndex[q+1])) > int64(min) {
 				return true
 			}
 		}

--- a/flow/scheduler.go
+++ b/flow/scheduler.go
@@ -474,7 +474,7 @@ func (scheduler *scheduler) schedule(schedTime uint) {
 						for q := 0; q < ff.instanceNumber; q++ {
 							var q1 int32
 							for q1 = 1; q1 < ff.instance[q].inIndex[0]+1; q1++ {
-								if low.CheckRSSPacketCount(ff.Parameters.(*receiveParameters).port, int16(ff.instance[q].inIndex[q1])) > RSSCloneMin {
+								if low.CheckRSSPacketCount(ff.Parameters.(*receiveParameters).port, int16(ff.instance[q].inIndex[q1])) > int64(RSSCloneMin) {
 									break
 								}
 							}

--- a/low/low.go
+++ b/low/low.go
@@ -71,8 +71,8 @@ func GetPort(n uint16) *Port {
 	return p
 }
 
-func CheckRSSPacketCount(p *Port, queue int16) uint32 {
-	return uint32(C.checkRSSPacketCount((*C.struct_cPort)(p), (C.int16_t(queue))))
+func CheckRSSPacketCount(p *Port, queue int16) int64 {
+	return int64(C.checkRSSPacketCount((*C.struct_cPort)(p), (C.int16_t(queue))))
 }
 
 // GetPortMACAddress gets MAC address of given port.


### PR DESCRIPTION
C.checkRSSPacketCount() is returning C.Int and the value could be -1:

```c
int checkRSSPacketCount(struct cPort *port, int16_t queue) {
	return rte_eth_rx_queue_count(port->PortId, queue);
}
```

[rte_eth_rx_queue_count](http://doc.dpdk.org/api/rte__ethdev_8h.html#af5e8c822c9c5f82879eb0c01ca50ea9c) in http://doc.dpdk.org/