### PR TITLE
F 1 Binding a device by NIC

### DIFF
--- a/devices/bind.go
+++ b/devices/bind.go
@@ -1,12 +1,22 @@
+// Copyright 2018 Intel Corporation.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package devices helps to query DPDK compatibles devices and to bind/unbind drivers
 package devices
 
 // Device is a DPDK compatible device and should be able to bind, unbind and
 // probe.
 type Device interface {
+	// Binds a driver to the device
 	Bind(driver string) error
+	// Unbinds the current driver from the device
 	Unbind() error
+	// Returns the name of the driver that is currently bound
 	CurrentDriver() (string, error)
+	// Probes the currently bound driver and checks if there is an error
 	Probe() error
+	// Returns the ID of the device
 	ID() string
 }
 

--- a/devices/bind.go
+++ b/devices/bind.go
@@ -1,0 +1,61 @@
+package devices
+
+type Device interface {
+	Bind(driver string) error
+	Unbind() error
+	CurrentDriver() (string, error)
+	Probe() error
+	Id() string
+}
+
+func NewDevices(devID string) (Device, error) {
+	if IsPciID.Match([]byte(devID)) {
+		return GetPciDeviceByPciID(devID)
+	} else {
+		return GetVmbusDeviceByUUID(devID)
+	}
+}
+
+func NewDeviceWithPciID(pciID string) (Device, error) {
+	device, err := GetPciDeviceByPciID(pciID)
+	if err != nil {
+		return nil, err
+	}
+
+	return device, nil
+}
+
+func NewDeviceWithUUID(uuid string) (Device, error) {
+	device, err := GetVmbusDeviceByUUID(uuid)
+	if err != nil {
+		return nil, err
+	}
+
+	return device, nil
+}
+
+func NewDeviceByNicName(nicName string) (Device, error) {
+	devID, err := GetDevID(nicName)
+	if err != nil {
+		return nil, err
+	}
+
+	device, err := NewDevices(devID)
+	if err != nil {
+		return nil, err
+	}
+
+	// setup devices by nicName
+	return device, nil
+}
+
+func New(input string) (Device, error) {
+	switch {
+	case IsPciID.Match([]byte(input)):
+		return NewDeviceWithPciID(input)
+	case IsUUID.Match([]byte(input)):
+		return NewDeviceWithUUID(input)
+	default:
+		return NewDeviceByNicName(input)
+	}
+}

--- a/devices/consts.go
+++ b/devices/consts.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 )
 
+// Driver names
 const (
 	DriverHvNetvcs      = "hv_netvcs"
 	DriverUioPciGeneric = "uio_pci_generic"
@@ -13,15 +14,36 @@ const (
 	DriverUioHvGeneric  = "uio_hv_generic"
 )
 
+// Path to PCI
 const (
 	PathSysPciDevices     = "/sys/bus/pci/devices"
 	PathSysPciDrivers     = "/sys/bus/pci/drivers"
 	PathSysPciDriverProbe = "/sys/bus/pci/drivers_probe"
 )
 
+// Path to VMBus
 const (
 	PathSysVmbusDevices = "/sys/bus/vmbus/devices"
 	PathSysVmbusDrivers = "/sys/bus/vmbus/drivers"
+)
+
+// Path to net
+const (
+	PathSysClassNet = "/sys/class/net"
+)
+
+// Regular expressions for PCI-ID and UUID
+var (
+	IsPciID *regexp.Regexp
+	IsUUID  *regexp.Regexp
+)
+
+// DPDK related drivers
+var (
+	DefaultDpdkDriver = DriverUioPciGeneric
+	DpdkDrivers       = [...]string{DriverUioPciGeneric, DriverIgUio, DriverVfioPci, DriverUioHvGeneric}
+	DpdkPciDrivers    = [...]string{DriverUioPciGeneric, DriverIgUio, DriverVfioPci}
+	DpdkVmbusDrivers  = [...]string{DriverUioHvGeneric}
 )
 
 type stringBuilder string
@@ -31,54 +53,43 @@ func (s stringBuilder) With(args ...interface{}) string {
 }
 
 var (
-	PathSysPciDevicesBind           stringBuilder = "/sys/bus/pci/devices/%s/driver/bind"
-	PathSysPciDevicesUnbind         stringBuilder = "/sys/bus/pci/devices/%s/driver/unbind"
-	PathSysPciDevicesOverrideDriver stringBuilder = "/sys/bus/pci/devices/%s/driver_override"
+	pathSysPciDevicesBind           stringBuilder = PathSysPciDevices + "/%s/driver/bind"
+	pathSysPciDevicesUnbind         stringBuilder = PathSysPciDevices + "/%s/driver/unbind"
+	pathSysPciDevicesOverrideDriver stringBuilder = PathSysPciDevices + "/%s/driver_override"
 
-	PathSysPciDriversBind   stringBuilder = "/sys/bus/pci/drivers/%s/bind"
-	PathSysPciDriversUnbind stringBuilder = "/sys/bus/pci/drivers/%s/unbind"
-	PathSysPciDriversNewID  stringBuilder = "/sys/bus/pci/drivers/%s/new_id"
+	pathSysPciDriversBind   stringBuilder = PathSysPciDrivers + "/%s/bind"
+	pathSysPciDriversUnbind stringBuilder = PathSysPciDrivers + "/%s/unbind"
+	pathSysPciDriversNewID  stringBuilder = PathSysPciDrivers + "/%s/new_id"
 )
 
 var (
-	PathSysVmbusDriversBind   stringBuilder = "/sys/bus/vmbus/drivers/%s/bind"
-	PathSysVmbusDriversUnbind stringBuilder = "/sys/bus/vmbus/drivers/%s/unbind"
-	PathSysVmbusDriversNewID  stringBuilder = "/sys/bus/vmbus/drivers/%s/new_id"
+	pathSysVmbusDriversBind   stringBuilder = PathSysVmbusDrivers + "/%s/bind"
+	pathSysVmbusDriversUnbind stringBuilder = PathSysVmbusDrivers + "/%s/unbind"
+	pathSysVmbusDriversNewID  stringBuilder = PathSysVmbusDrivers + "/%s/new_id"
 )
 
 var (
-	PathSysClassNetDeviceDriver stringBuilder = "/sys/class/net/%s/device/driver"
-	PathSysClassNetDevice       stringBuilder = "/sys/class/net/%s/device"
+	pathSysClassNetDeviceDriver stringBuilder = PathSysClassNet + "/%s/device/driver"
+	pathSysClassNetDevice       stringBuilder = PathSysClassNet + "/%s/device"
 )
 
 var (
-	VmbusDeviceStringer stringBuilder = "ID: %s\nClass:\t%s\nDriver:\t%s"
-	PciDeviceStringer   stringBuilder = "ID: %s\nClass:\t%s\nVendor:\t%s\nDevice:\t%s\nDriver:\t%s"
+	vmbusDeviceStringer stringBuilder = "ID: %s\nClass:\t%s\nDriver:\t%s"
+	pciDeviceStringer   stringBuilder = "ID: %s\nClass:\t%s\nVendor:\t%s\nDevice:\t%s\nDriver:\t%s"
 )
 
 var (
-	DefaultDpdkDriver = DriverUioPciGeneric
-	DpdkDrivers       = [...]string{DriverUioPciGeneric, DriverIgUio, DriverVfioPci, DriverUioHvGeneric}
-	DpdkPciDrivers    = [...]string{DriverUioPciGeneric, DriverIgUio, DriverVfioPci}
-	DpdkVmbusDrivers  = [...]string{DriverUioHvGeneric}
-)
-
-var (
-	// NOTE: this is for ethtool output
+	// for ethtool output
 	rPciIDForEthtool *regexp.Regexp
 
-	// NOTE: these is for lspci output
+	// for lspci output
 	rPciClass  *regexp.Regexp
 	rPciVendor *regexp.Regexp
 	rPciDevice *regexp.Regexp
 	rPciDriver *regexp.Regexp
 
+	// for find output
 	rVmbusDriver *regexp.Regexp
-)
-
-var (
-	IsPciID *regexp.Regexp
-	IsUUID  *regexp.Regexp
 )
 
 func init() {

--- a/devices/consts.go
+++ b/devices/consts.go
@@ -1,0 +1,96 @@
+package devices
+
+import (
+	"fmt"
+	"regexp"
+)
+
+const (
+	DriverUioPciGeneric = "uio_pci_generic"
+	DriverIgUio         = "ig_uio"
+	DriverVfioPci       = "vfio-pci"
+	DriverVfioPciKoName = "vfio_pci"
+	DriverUioHvGeneric  = "uio_hv_generic"
+)
+
+const (
+	PathSysPciDevices     = "/sys/bus/pci/devices"
+	PathSysPciDrivers     = "/sys/bus/pci/drivers"
+	PathSysPciDriverProbe = "/sys/bus/pci/drivers_probe"
+)
+
+const (
+	PathSysVmbusDevices = "/sys/bus/vmbus/devices"
+	PathSysVmbusDrivers = "/sys/bus/vmbus/drivers"
+)
+
+type StringBuilder string
+
+func (s StringBuilder) With(args ...interface{}) string {
+	return fmt.Sprintf(string(s), args...)
+}
+
+var (
+	PathSysPciDevicesBind           StringBuilder = "/sys/bus/pci/devices/%s/driver/bind"
+	PathSysPciDevicesUnbind         StringBuilder = "/sys/bus/pci/devices/%s/driver/unbind"
+	PathSysPciDevicesOverrideDriver StringBuilder = "/sys/bus/pci/devices/%s/driver_override"
+
+	PathSysPciDriversBind   StringBuilder = "/sys/bus/pci/drivers/%s/bind"
+	PathSysPciDriversUnbind StringBuilder = "/sys/bus/pci/drivers/%s/unbind"
+	PathSysPciDriversNewID  StringBuilder = "/sys/bus/pci/drivers/%s/new_id"
+)
+
+var (
+	PathSysVmbusDriversBind   StringBuilder = "/sys/bus/vmbus/drivers/%s/bind"
+	PathSysVmbusDriversUnbind StringBuilder = "/sys/bus/vmbus/drivers/%s/unbind"
+	PathSysVmbusDriversNewID  StringBuilder = "/sys/bus/vmbus/drivers/%s/new_id"
+)
+
+var (
+	PathSysClassNetDeviceDriver StringBuilder = "/sys/class/net/%s/device/driver"
+	PathSysClassNetDevice       StringBuilder = "/sys/class/net/%s/device"
+)
+
+var (
+	VmbusDeviceStringer StringBuilder = "ID: %s\nClass:\t%s\nDriver:\t%s"
+	PciDeviceStringer   StringBuilder = "ID: %s\nClass:\t%s\nVendor:\t%s\nDevice:\t%s\nDriver:\t%s"
+)
+
+var (
+	DefaultDpdkDriver = DriverUioPciGeneric
+	DpdkDrivers       = [...]string{DriverUioPciGeneric, DriverIgUio, DriverVfioPci, DriverUioHvGeneric}
+	DpdkPciDrivers    = [...]string{DriverUioPciGeneric, DriverIgUio, DriverVfioPci}
+	DpdkVmbusDrivers  = [...]string{DriverUioHvGeneric}
+)
+
+var (
+	// NOTE: this is for ethtool output
+	rPciIDForEthtool *regexp.Regexp
+
+	// NOTE: these is for lspci output
+	rPciClass  *regexp.Regexp
+	rPciVendor *regexp.Regexp
+	rPciDevice *regexp.Regexp
+	rPciDriver *regexp.Regexp
+
+	rVmbusDriver *regexp.Regexp
+)
+
+var (
+	IsPciID *regexp.Regexp
+	IsUUID  *regexp.Regexp
+)
+
+func init() {
+	rPciIDForEthtool = regexp.MustCompile("bus-info:\\s([0-9:.]+)")
+
+	rPciClass = regexp.MustCompile("[Cc]lass:\\s([0-9a-zA-Z]{4})")
+	rPciVendor = regexp.MustCompile("[Vv]endor:\\s([0-9a-zA-Z]{4})")
+	rPciDevice = regexp.MustCompile("[Dd]evice:\\s([0-9a-zA-Z]{4})")
+	rPciDriver = regexp.MustCompile("[Dd]river:\\s(\\S+)")
+
+	rVmbusDriver = regexp.MustCompile("/sys/bus/vmbus/drivers/(\\S+)/")
+
+	IsPciID = regexp.MustCompile("^\\d{4}:\\d{2}:\\d{2}.\\d$")
+	IsUUID = regexp.MustCompile("^[[:xdigit:]]{8}-[[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{12}$")
+}

--- a/devices/consts.go
+++ b/devices/consts.go
@@ -6,6 +6,7 @@ import (
 )
 
 const (
+	DriverHvNetvcs      = "hv_netvcs"
 	DriverUioPciGeneric = "uio_pci_generic"
 	DriverIgUio         = "ig_uio"
 	DriverVfioPci       = "vfio-pci"

--- a/devices/consts.go
+++ b/devices/consts.go
@@ -9,7 +9,6 @@ const (
 	DriverUioPciGeneric = "uio_pci_generic"
 	DriverIgUio         = "ig_uio"
 	DriverVfioPci       = "vfio-pci"
-	DriverVfioPciKoName = "vfio_pci"
 	DriverUioHvGeneric  = "uio_hv_generic"
 )
 
@@ -24,36 +23,36 @@ const (
 	PathSysVmbusDrivers = "/sys/bus/vmbus/drivers"
 )
 
-type StringBuilder string
+type stringBuilder string
 
-func (s StringBuilder) With(args ...interface{}) string {
+func (s stringBuilder) With(args ...interface{}) string {
 	return fmt.Sprintf(string(s), args...)
 }
 
 var (
-	PathSysPciDevicesBind           StringBuilder = "/sys/bus/pci/devices/%s/driver/bind"
-	PathSysPciDevicesUnbind         StringBuilder = "/sys/bus/pci/devices/%s/driver/unbind"
-	PathSysPciDevicesOverrideDriver StringBuilder = "/sys/bus/pci/devices/%s/driver_override"
+	PathSysPciDevicesBind           stringBuilder = "/sys/bus/pci/devices/%s/driver/bind"
+	PathSysPciDevicesUnbind         stringBuilder = "/sys/bus/pci/devices/%s/driver/unbind"
+	PathSysPciDevicesOverrideDriver stringBuilder = "/sys/bus/pci/devices/%s/driver_override"
 
-	PathSysPciDriversBind   StringBuilder = "/sys/bus/pci/drivers/%s/bind"
-	PathSysPciDriversUnbind StringBuilder = "/sys/bus/pci/drivers/%s/unbind"
-	PathSysPciDriversNewID  StringBuilder = "/sys/bus/pci/drivers/%s/new_id"
+	PathSysPciDriversBind   stringBuilder = "/sys/bus/pci/drivers/%s/bind"
+	PathSysPciDriversUnbind stringBuilder = "/sys/bus/pci/drivers/%s/unbind"
+	PathSysPciDriversNewID  stringBuilder = "/sys/bus/pci/drivers/%s/new_id"
 )
 
 var (
-	PathSysVmbusDriversBind   StringBuilder = "/sys/bus/vmbus/drivers/%s/bind"
-	PathSysVmbusDriversUnbind StringBuilder = "/sys/bus/vmbus/drivers/%s/unbind"
-	PathSysVmbusDriversNewID  StringBuilder = "/sys/bus/vmbus/drivers/%s/new_id"
+	PathSysVmbusDriversBind   stringBuilder = "/sys/bus/vmbus/drivers/%s/bind"
+	PathSysVmbusDriversUnbind stringBuilder = "/sys/bus/vmbus/drivers/%s/unbind"
+	PathSysVmbusDriversNewID  stringBuilder = "/sys/bus/vmbus/drivers/%s/new_id"
 )
 
 var (
-	PathSysClassNetDeviceDriver StringBuilder = "/sys/class/net/%s/device/driver"
-	PathSysClassNetDevice       StringBuilder = "/sys/class/net/%s/device"
+	PathSysClassNetDeviceDriver stringBuilder = "/sys/class/net/%s/device/driver"
+	PathSysClassNetDevice       stringBuilder = "/sys/class/net/%s/device"
 )
 
 var (
-	VmbusDeviceStringer StringBuilder = "ID: %s\nClass:\t%s\nDriver:\t%s"
-	PciDeviceStringer   StringBuilder = "ID: %s\nClass:\t%s\nVendor:\t%s\nDevice:\t%s\nDriver:\t%s"
+	VmbusDeviceStringer stringBuilder = "ID: %s\nClass:\t%s\nDriver:\t%s"
+	PciDeviceStringer   stringBuilder = "ID: %s\nClass:\t%s\nVendor:\t%s\nDevice:\t%s\nDriver:\t%s"
 )
 
 var (

--- a/devices/consts.go
+++ b/devices/consts.go
@@ -1,3 +1,8 @@
+// Copyright 2018 Intel Corporation.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package devices helps to query DPDK compatibles devices and to bind/unbind drivers
 package devices
 
 import (

--- a/devices/errno.go
+++ b/devices/errno.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 )
 
+// Errors of devices package
 var (
 	ErrNoBoundDriver         = errors.New("no driver is bound to the device")
 	ErrAlreadyBoundDriver    = errors.New("device has already bound the selected driver")

--- a/devices/errno.go
+++ b/devices/errno.go
@@ -1,0 +1,15 @@
+package devices
+
+import (
+	"errors"
+)
+
+var (
+	ErrNoBoundDriver         = errors.New("No driver is bound to the device.")
+	ErrAlreadyBoundDriver    = errors.New("Device is already bound to selected driver.")
+	ErrBind                  = errors.New("Fail to bind driver.")
+	ErrUnbind                = errors.New("Fail to unbind driver.")
+	ErrUnsupportedDriver     = errors.New("Unsupported DPDK driver.")
+	ErrNotProbe              = errors.New("Devices didn't support drive_probe.")
+	ErrKernelModuleNotLoaded = errors.New("Kernel module not loaded.")
+)

--- a/devices/errno.go
+++ b/devices/errno.go
@@ -1,3 +1,8 @@
+// Copyright 2018 Intel Corporation.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package devices helps to query DPDK compatibles devices and to bind/unbind drivers
 package devices
 
 import (

--- a/devices/errno.go
+++ b/devices/errno.go
@@ -5,11 +5,11 @@ import (
 )
 
 var (
-	ErrNoBoundDriver         = errors.New("No driver is bound to the device.")
-	ErrAlreadyBoundDriver    = errors.New("Device is already bound to selected driver.")
-	ErrBind                  = errors.New("Fail to bind driver.")
-	ErrUnbind                = errors.New("Fail to unbind driver.")
-	ErrUnsupportedDriver     = errors.New("Unsupported DPDK driver.")
-	ErrNotProbe              = errors.New("Devices didn't support drive_probe.")
-	ErrKernelModuleNotLoaded = errors.New("Kernel module not loaded.")
+	ErrNoBoundDriver         = errors.New("no driver is bound to the device")
+	ErrAlreadyBoundDriver    = errors.New("device has already bound the selected driver")
+	ErrBind                  = errors.New("fail to bind the driver")
+	ErrUnbind                = errors.New("fail to unbind the driver")
+	ErrUnsupportedDriver     = errors.New("unsupported DPDK driver")
+	ErrNotProbe              = errors.New("device doesn't support 'drive_probe'")
+	ErrKernelModuleNotLoaded = errors.New("kernel module is not loaded")
 )

--- a/devices/misc.go
+++ b/devices/misc.go
@@ -10,7 +10,7 @@ import (
 	"time"
 )
 
-var DefaultTimeoutLimitation = 5 * time.Second
+var defaultTimeoutLimitation = 5 * time.Second
 
 func FindDefaultDpdkDriver(nicName string) string {
 	driver, err := readlinkBaseCmd(PathSysClassNetDeviceDriver.With(nicName))
@@ -18,20 +18,21 @@ func FindDefaultDpdkDriver(nicName string) string {
 		return DefaultDpdkDriver
 	}
 	switch driver {
-	case "hv_netvcs":
+	case DriverHvNetvcs:
 		return DriverUioHvGeneric
 	default:
 		return DefaultDpdkDriver
 	}
 }
 
-func GetDevID(nicName string) (string, error) {
+func GetDeviceID(nicName string) (string, error) {
 	// DEV_ID=$(basename $(readlink /sys/class/net/<nicName>/device))
 	return readlinkBaseCmd(PathSysClassNetDevice.With(nicName))
 }
 
+// IsModuleLoaded checks if the kernel has already loaded the driver or not.
 func IsModuleLoaded(driver string) bool {
-	output, err := cmdOutputWithTimeout(DefaultTimeoutLimitation, "lsmod")
+	output, err := cmdOutputWithTimeout(defaultTimeoutLimitation, "lsmod")
 	if err != nil {
 		// Can't run lsmod, return false
 		return false
@@ -48,20 +49,20 @@ func IsModuleLoaded(driver string) bool {
 func writeToTargetWithData(sysfs string, flag int, mode os.FileMode, data string) error {
 	writer, err := os.OpenFile(sysfs, flag, mode)
 	if err != nil {
-		return fmt.Errorf("OpenFile failed %s", err.Error())
+		return fmt.Errorf("OpenFile failed: %s", err.Error())
 	}
 	defer writer.Close()
 
 	_, err = writer.Write([]byte(data))
 	if err != nil {
-		return fmt.Errorf("WriteFile failed %s", err.Error())
+		return fmt.Errorf("WriteFile failed: %s", err.Error())
 	}
 
 	return nil
 }
 
 func readlinkBaseCmd(path string) (string, error) {
-	output, err := cmdOutputWithTimeout(DefaultTimeoutLimitation, "readlink", path)
+	output, err := cmdOutputWithTimeout(defaultTimeoutLimitation, "readlink", path)
 	if err != nil {
 		return "", fmt.Errorf("Cmd Execute readlink failed: %s", err.Error())
 	}

--- a/devices/misc.go
+++ b/devices/misc.go
@@ -12,6 +12,8 @@ import (
 
 var defaultTimeoutLimitation = 5 * time.Second
 
+// FindDefaultDpdkDriver returns a default DPDK driver that the given NIC can
+// use.
 func FindDefaultDpdkDriver(nicName string) string {
 	driver, err := readlinkBaseCmd(pathSysClassNetDeviceDriver.With(nicName))
 	if err != nil {
@@ -25,6 +27,7 @@ func FindDefaultDpdkDriver(nicName string) string {
 	}
 }
 
+// GetDeviceID returns the device ID of given NIC name.
 func GetDeviceID(nicName string) (string, error) {
 	// DEV_ID=$(basename $(readlink /sys/class/net/<nicName>/device))
 	return readlinkBaseCmd(pathSysClassNetDevice.With(nicName))

--- a/devices/misc.go
+++ b/devices/misc.go
@@ -13,7 +13,7 @@ import (
 var defaultTimeoutLimitation = 5 * time.Second
 
 func FindDefaultDpdkDriver(nicName string) string {
-	driver, err := readlinkBaseCmd(PathSysClassNetDeviceDriver.With(nicName))
+	driver, err := readlinkBaseCmd(pathSysClassNetDeviceDriver.With(nicName))
 	if err != nil {
 		return DefaultDpdkDriver
 	}
@@ -27,7 +27,7 @@ func FindDefaultDpdkDriver(nicName string) string {
 
 func GetDeviceID(nicName string) (string, error) {
 	// DEV_ID=$(basename $(readlink /sys/class/net/<nicName>/device))
-	return readlinkBaseCmd(PathSysClassNetDevice.With(nicName))
+	return readlinkBaseCmd(pathSysClassNetDevice.With(nicName))
 }
 
 // IsModuleLoaded checks if the kernel has already loaded the driver or not.

--- a/devices/misc.go
+++ b/devices/misc.go
@@ -1,3 +1,8 @@
+// Copyright 2018 Intel Corporation.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package devices helps to query DPDK compatibles devices and to bind/unbind drivers
 package devices
 
 import (

--- a/devices/pci.go
+++ b/devices/pci.go
@@ -1,0 +1,224 @@
+package devices
+
+import (
+	"fmt"
+	"os"
+)
+
+type PciDevice struct {
+	ID     string
+	Class  string
+	Vendor string
+	Device string
+	Driver string
+}
+
+// GetPciDevice Get device info by PCI bus id.
+func GetPciDeviceByPciID(pciID string) (Device, error) {
+	output, err := cmdOutputWithTimeout(DefaultTimeoutLimitation, "lspci", "-Dvmmnks", pciID)
+	if err != nil {
+		return nil, err
+	}
+
+	info := &PciDevice{ID: pciID}
+
+	match := rPciClass.FindSubmatch(output)
+	if len(match) < 2 {
+		return nil, fmt.Errorf("Bad lspci output: %s", output)
+	}
+	info.Class = string(match[1][:])
+
+	match = rPciVendor.FindSubmatch(output)
+	if len(match) < 2 {
+		return nil, fmt.Errorf("Bad lspci output: %s", output)
+	}
+	info.Vendor = string(match[1][:])
+
+	match = rPciDevice.FindSubmatch(output)
+	if len(match) < 2 {
+		return nil, fmt.Errorf("Bad lspci output: %s", output)
+	}
+	info.Device = string(match[1][:])
+
+	match = rPciDriver.FindSubmatch(output)
+	// driver may be empty
+	if len(match) >= 2 {
+		info.Driver = string(match[1][:])
+	}
+
+	return info, nil
+}
+
+func (p *PciDevice) Bind(driver string) error {
+	var err error
+	p.Driver, err = BindPci(p.ID, driver, p.Vendor, p.Device)
+	return err
+}
+
+func (p *PciDevice) Unbind() error {
+	return UnbindPci(p.ID, p.Driver)
+}
+
+func (p *PciDevice) Probe() error {
+	var err error
+	p.Driver, err = ProbePci(p.ID)
+	return err
+
+}
+
+func (p *PciDevice) CurrentDriver() (string, error) {
+	return GetCurrentPciDriver(p.ID)
+}
+
+func (p *PciDevice) Id() string {
+	return p.ID
+}
+
+func BindPci(devID, driver, vendor, device string) (string, error) {
+	current, err := GetCurrentPciDriver(devID)
+	if err != nil {
+		return "", err
+	}
+
+	switch current {
+	case driver:
+		// already binding the same driver, skip binding it
+		return driver, nil
+	case "":
+		// if not binding to any driver, continue to bind pci device driver
+	default:
+		// if there already binding to other driver, unbind it first
+		if err := unbindPciDeviceDriver(devID, current); err != nil {
+			return "", err
+		}
+	}
+
+	if err := bindPciDeviceDriver(devID, driver, vendor, device); err != nil {
+		return "", err
+	}
+
+	return driver, nil
+}
+
+func UnbindPci(devID, driver string) error {
+	current, err := GetCurrentPciDriver(devID)
+	if err != nil {
+		return err
+	} else if current == "" {
+		// this device is already not bounding to any driver
+		return nil
+	}
+
+	return unbindPciDeviceDriver(devID, current)
+}
+
+func ProbePci(devID string) (string, error) {
+	if err := probePciDriver(devID); err != nil {
+		return "", err
+	}
+
+	return GetCurrentPciDriver(devID)
+}
+
+// bindPciDeviceDriver bind driver to device in follow flow
+// 0. make sure device already unbound to any driver
+// 1. set sysfs device driver_override to target driver
+// 2. try binding driver
+// 3. clean up device driver_override
+// 4. if driver_override failed, try to use sysfs driver/.../new_id to bind device
+func bindPciDeviceDriver(devID, driver, vendor, device string) error {
+	if err := overrideDriver(devID, driver); err == nil {
+		defer cleanOverrideDriver(devID)
+
+		// normal way to bind pci driver
+		if err := writeToTargetWithData(PathSysPciDriversBind.With(driver), os.O_WRONLY, 0200, devID); err != nil {
+			return err
+		}
+
+		if current, _ := GetCurrentPciDriver(devID); current != driver {
+			return ErrBind
+		}
+		return nil
+	}
+
+	// NOTE if driver_override failed, means kernel version < 3.15
+	// means we need to use sysfs drivers/.../new_id to bind device
+	if err := addToDriver(devID, driver, vendor, device); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func unbindPciDeviceDriver(devID, driver string) error {
+	// first trying write to PathSysPciDevicesUnbindWithDevID, if fails, try next, write to PathSysPciDriversUnbindWithDriver
+	if err := writeToTargetWithData(PathSysPciDevicesUnbind.With(devID), os.O_WRONLY, 0200, devID); err != nil {
+		if err := writeToTargetWithData(PathSysPciDriversUnbind.With(driver), os.O_WRONLY, 0200, devID); err != nil {
+			return err
+		}
+	}
+
+	// check if unbind success
+	current, err := GetCurrentPciDriver(devID)
+	if err != nil {
+		return err
+	}
+	if current != "" {
+		return ErrUnbind
+	}
+
+	return nil
+}
+
+func isValidDpdkPciDriver(driver string) bool {
+	for _, dpdkDriver := range DpdkPciDrivers {
+		if driver == dpdkDriver {
+			return true
+		}
+	}
+	return false
+}
+
+func probePciDriver(devID string) error {
+	return writeToTargetWithData(PathSysPciDriverProbe, os.O_WRONLY, 0200, devID)
+}
+
+func overrideDriver(devID, driver string) error {
+	return writeToTargetWithData(PathSysPciDevicesOverrideDriver.With(devID), os.O_WRONLY|os.O_TRUNC, 0755, driver)
+}
+
+func cleanOverrideDriver(devID string) error {
+	return overrideDriver(devID, "\x00")
+}
+
+func addToDriver(devID, driver, vendor, device string) error {
+	// see https://www.kernel.org/doc/Documentation/ABI/testing/sysfs-bus-pci
+	// The format for the device ID is: VVVV DDDD SVVV SDDD CCCC MMMM PPPP.
+	// VVVV Vendor ID
+	// DDDD Device ID
+	// SVVV Subsystem Vendor ID
+	// SDDD ubsystem Device ID
+	// CCCC Class
+	// MMMM Class Mask
+	// PPPP Private Driver Data
+	return writeToTargetWithData(PathSysPciDriversNewID.With(driver), os.O_WRONLY, 0200, vendor+" "+device)
+}
+
+func (p *PciDevice) String() string {
+	return PciDeviceStringer.With(p.ID, p.Class, p.Vendor, p.Device, p.Driver)
+}
+
+// GetCurrentPciDriver update the current driver device bound to.
+func GetCurrentPciDriver(id string) (string, error) {
+	output, err := cmdOutputWithTimeout(DefaultTimeoutLimitation, "lspci", "-Dvmmnks", id)
+	if err != nil {
+		return "", fmt.Errorf("Cmd Execute lspci failed: %s", err.Error())
+	}
+
+	match := rPciDriver.FindSubmatch(output)
+	if len(match) >= 2 {
+		return string(match[1][:]), nil
+	}
+
+	return "", nil
+}

--- a/devices/pci.go
+++ b/devices/pci.go
@@ -130,7 +130,7 @@ func bindPciDeviceDriver(devID, driver, vendor, device string) error {
 		defer cleanOverrideDriver(devID)
 
 		// normal way to bind pci driver
-		if err := writeToTargetWithData(PathSysPciDriversBind.With(driver), os.O_WRONLY, 0200, devID); err != nil {
+		if err := writeToTargetWithData(pathSysPciDriversBind.With(driver), os.O_WRONLY, 0200, devID); err != nil {
 			return err
 		}
 
@@ -146,9 +146,9 @@ func bindPciDeviceDriver(devID, driver, vendor, device string) error {
 }
 
 func unbindPciDeviceDriver(devID, driver string) error {
-	// first trying write to PathSysPciDevicesUnbindWithDevID, if fails, try next, write to PathSysPciDriversUnbindWithDriver
-	if err := writeToTargetWithData(PathSysPciDevicesUnbind.With(devID), os.O_WRONLY, 0200, devID); err != nil {
-		if err := writeToTargetWithData(PathSysPciDriversUnbind.With(driver), os.O_WRONLY, 0200, devID); err != nil {
+	// first trying write to pathSysPciDevicesUnbindWithDevID, if fails, try next, write to pathSysPciDriversUnbindWithDriver
+	if err := writeToTargetWithData(pathSysPciDevicesUnbind.With(devID), os.O_WRONLY, 0200, devID); err != nil {
+		if err := writeToTargetWithData(pathSysPciDriversUnbind.With(driver), os.O_WRONLY, 0200, devID); err != nil {
 			return err
 		}
 	}
@@ -171,7 +171,7 @@ func probePciDriver(devID string) error {
 }
 
 func overrideDriver(devID, driver string) error {
-	return writeToTargetWithData(PathSysPciDevicesOverrideDriver.With(devID), os.O_WRONLY|os.O_TRUNC, 0755, driver)
+	return writeToTargetWithData(pathSysPciDevicesOverrideDriver.With(devID), os.O_WRONLY|os.O_TRUNC, 0755, driver)
 }
 
 func cleanOverrideDriver(devID string) error {
@@ -188,11 +188,11 @@ func addToDriver(devID, driver, vendor, device string) error {
 	// CCCC Class
 	// MMMM Class Mask
 	// PPPP Private Driver Data
-	return writeToTargetWithData(PathSysPciDriversNewID.With(driver), os.O_WRONLY, 0200, vendor+" "+device)
+	return writeToTargetWithData(pathSysPciDriversNewID.With(driver), os.O_WRONLY, 0200, vendor+" "+device)
 }
 
 func (p *PciDevice) String() string {
-	return PciDeviceStringer.With(p.ID, p.Class, p.Vendor, p.Device, p.Driver)
+	return pciDeviceStringer.With(p.ID, p.Class, p.Vendor, p.Device, p.Driver)
 }
 
 // GetCurrentPciDriver update the current driver device bound to.

--- a/devices/pci.go
+++ b/devices/pci.go
@@ -1,3 +1,8 @@
+// Copyright 2018 Intel Corporation.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package devices helps to query DPDK compatibles devices and to bind/unbind drivers
 package devices
 
 import (

--- a/devices/vmbus.go
+++ b/devices/vmbus.go
@@ -1,0 +1,160 @@
+package devices
+
+import (
+	"fmt"
+	"os"
+)
+
+/*
+   DEV_UUID=$(basename $(readlink /sys/class/net/eth1/device))
+
+   # only on kernel 4.18 or later
+   driverctl -b vmbus set-override $DEV_UUID uio_hv_generic
+
+   # others
+   modprobe uio_hv_generic
+   NET_UUID="f8615163-df3e-46c5-913f-f2d2f965ed0e"
+   echo $NET_UUID > /sys/bus/vmbus/drivers/uio_hv_generic/new_id // only run once
+   echo $DEV_UUID > /sys/bus/vmbus/drivers/hv_netvsc/unbind
+   echo $DEV_UUID > /sys/bus/vmbus/drivers/uio_hv_generic/bind
+*/
+
+type prepareFunc func() error
+
+type VmbusDevice struct {
+	UUID   string
+	Driver string
+}
+
+func GetVmbusDeviceByUUID(uuid string) (Device, error) {
+	result := &VmbusDevice{UUID: uuid}
+	return result, nil
+}
+
+func (v *VmbusDevice) Bind(driver string) error {
+	current, err := GetCurrentVmbusDriver(v.UUID)
+	if err != nil {
+		return fmt.Errorf("GetCurrentVmbusDriver: %s", err.Error())
+	}
+	var prepare prepareFunc
+
+	switch current {
+	case driver:
+		// already binding the same driver, skip binding it
+		return nil
+	case "":
+		// if not binding to any driver, continue to bind pci device driver
+	default:
+		// if there already binding to other driver, unbind it first
+		prepare = func() error {
+			if err := unbindVmbusDeviceDriver(v.UUID, current); err != nil {
+				return fmt.Errorf("unbindVmbusDeviceDriver: %s", err.Error())
+			}
+			return nil
+		}
+	}
+
+	if isValidDpdkVmbusDriver(driver) {
+		if err := bindVmbusDeviceDpdkDriver(v.UUID, driver, prepare); err != nil {
+			return fmt.Errorf("bindVmbusDeviceDriver: %s", err.Error())
+		}
+	} else {
+		if err := bindVmbusDeviceDriver(v.UUID, driver, prepare); err != nil {
+			return fmt.Errorf("bindVmbusDeviceDriver: %s", err.Error())
+		}
+	}
+	// update Driver
+	v.Driver = driver
+
+	return nil
+}
+
+func (v *VmbusDevice) Unbind() error {
+	current, err := GetCurrentVmbusDriver(v.UUID)
+	if err != nil {
+		return err
+	}
+	if current == "" {
+		// NOTE: if no current vmbus driver, don't unbind it and don't return error
+		return nil
+	}
+	return unbindVmbusDeviceDriver(v.UUID, current)
+}
+
+func (v *VmbusDevice) CurrentDriver() (string, error) {
+	return GetCurrentVmbusDriver(v.UUID)
+}
+
+func (v *VmbusDevice) Probe() error {
+	return ErrNotProbe
+}
+
+func (v *VmbusDevice) Id() string {
+	return v.UUID
+}
+
+func (v *VmbusDevice) String() string {
+	return VmbusDeviceStringer.With(v.UUID, v.Driver)
+}
+
+func bindVmbusDeviceDriver(devUUID, driver string, prepares ...prepareFunc) error {
+	for _, prepare := range prepares {
+		if prepare == nil {
+			continue
+		}
+		if err := prepare(); err != nil {
+			return err
+		}
+	}
+	return writeToTargetWithData(PathSysVmbusDriversBind.With(driver), os.O_WRONLY, 0200, devUUID)
+}
+
+func bindVmbusDeviceDpdkDriver(devUUID, driver string, prepares ...prepareFunc) error {
+	// NOTE: ignore error of write vmbus driver new_id
+	writeToTargetWithData(PathSysVmbusDriversNewID.With(driver), os.O_WRONLY, 0200, NewNetUUID())
+	return bindVmbusDeviceDriver(devUUID, driver, prepares...)
+}
+
+func unbindVmbusDeviceDriver(devUUID, driver string) error {
+	return writeToTargetWithData(PathSysVmbusDriversUnbind.With(driver), os.O_WRONLY, 0200, devUUID)
+}
+
+func isValidDpdkVmbusDriver(driver string) bool {
+	for _, dpdkDriver := range DpdkVmbusDrivers {
+		if driver == dpdkDriver {
+			return true
+		}
+	}
+	return false
+}
+
+// GetCurrentVmbusDriver update the current driver device bound to.
+func GetCurrentVmbusDriver(uuid string) (string, error) {
+	output, err := cmdOutputWithTimeout(DefaultTimeoutLimitation, "find", PathSysVmbusDrivers, "-type", "l", "-iname", uuid)
+	if err != nil {
+		return "", fmt.Errorf("Cmd Execute find failed: %s", err.Error())
+	}
+
+	matches := rVmbusDriver.FindSubmatch(output)
+	if len(matches) >= 2 {
+		return string(matches[1]), nil
+	}
+
+	return "", nil
+}
+
+// NewNetUUID return a net uuid
+// FIXME: dummy implement, always return same result
+func NewNetUUID() string {
+	return "f8615163-df3e-46c5-913f-f2d2f965ed0e"
+}
+
+// bindVmbusDeviceDriverKernelGreaterThan418 only available on linux kernel >= 4.18
+func bindVmbusDeviceDriverKernelGreaterThan418(devUUID, driver string) error {
+	// driverctl -b vmbus set-override $DEV_UUID uio_hv_generic
+	_, err := cmdOutputWithTimeout(DefaultTimeoutLimitation, "driverctl", "-b", "vmbus", "set-override", devUUID, driver)
+	if err != nil {
+		return fmt.Errorf("Cmd Execute driverctl failed: %s", err.Error())
+	}
+	return nil
+}

--- a/devices/vmbus.go
+++ b/devices/vmbus.go
@@ -95,7 +95,7 @@ func (v *VmbusDevice) ID() string {
 }
 
 func (v *VmbusDevice) String() string {
-	return VmbusDeviceStringer.With(v.UUID, v.Driver)
+	return vmbusDeviceStringer.With(v.UUID, v.Driver)
 }
 
 // GetCurrentVmbusDriver update the current driver device bound to.
@@ -122,17 +122,17 @@ func bindVmbusDeviceDriver(devUUID, driver string, prepares ...prepareFunc) erro
 			return err
 		}
 	}
-	return writeToTargetWithData(PathSysVmbusDriversBind.With(driver), os.O_WRONLY, 0200, devUUID)
+	return writeToTargetWithData(pathSysVmbusDriversBind.With(driver), os.O_WRONLY, 0200, devUUID)
 }
 
 func bindVmbusDeviceDpdkDriver(devUUID, driver string, prepares ...prepareFunc) error {
 	// NOTE: ignore error of write vmbus driver new_id
-	writeToTargetWithData(PathSysVmbusDriversNewID.With(driver), os.O_WRONLY, 0200, newNetUUID())
+	writeToTargetWithData(pathSysVmbusDriversNewID.With(driver), os.O_WRONLY, 0200, newNetUUID())
 	return bindVmbusDeviceDriver(devUUID, driver, prepares...)
 }
 
 func unbindVmbusDeviceDriver(devUUID, driver string) error {
-	return writeToTargetWithData(PathSysVmbusDriversUnbind.With(driver), os.O_WRONLY, 0200, devUUID)
+	return writeToTargetWithData(pathSysVmbusDriversUnbind.With(driver), os.O_WRONLY, 0200, devUUID)
 }
 
 func isValidDpdkVmbusDriver(driver string) bool {

--- a/devices/vmbus.go
+++ b/devices/vmbus.go
@@ -147,12 +147,13 @@ func isValidDpdkVmbusDriver(driver string) bool {
 
 // newNetUUID returns a valid net UUID
 // FIXME: Dummy implement, always return same result - see
-// https://doc.dpdk.org/guides/nics/netvsc.html NET_UUID
+// https://doc.dpdk.org/guides/nics/netvsc.html#installation NET_UUID
 func newNetUUID() string {
 	return "f8615163-df3e-46c5-913f-f2d2f965ed0e"
 }
 
 // bindVmbusDeviceDriverKernelGreaterThan418 is only available on linux kernel >= 4.18
+// XXX: see https://doc.dpdk.org/guides/nics/netvsc.html#installation
 func bindVmbusDeviceDriverKernelGreaterThan418(devUUID, driver string) error {
 	// driverctl -b vmbus set-override $DEV_UUID uio_hv_generic
 	_, err := cmdOutputWithTimeout(defaultTimeoutLimitation, "driverctl", "-b", "vmbus", "set-override", devUUID, driver)

--- a/devices/vmbus.go
+++ b/devices/vmbus.go
@@ -21,17 +21,18 @@ import (
 
 type prepareFunc func() error
 
-type VmbusDevice struct {
+type vmbusDevice struct {
 	UUID   string
 	Driver string
 }
 
+// GetVmbusDeviceByUUID returns a VMBus device by given UUID.
 func GetVmbusDeviceByUUID(uuid string) (Device, error) {
-	result := &VmbusDevice{UUID: uuid}
+	result := &vmbusDevice{UUID: uuid}
 	return result, nil
 }
 
-func (v *VmbusDevice) Bind(driver string) error {
+func (v *vmbusDevice) Bind(driver string) error {
 	current, err := GetCurrentVmbusDriver(v.UUID)
 	if err != nil {
 		return fmt.Errorf("GetCurrentVmbusDriver: %s", err.Error())
@@ -70,7 +71,7 @@ func (v *VmbusDevice) Bind(driver string) error {
 	return nil
 }
 
-func (v *VmbusDevice) Unbind() error {
+func (v *vmbusDevice) Unbind() error {
 	current, err := GetCurrentVmbusDriver(v.UUID)
 	if err != nil {
 		return err
@@ -82,19 +83,19 @@ func (v *VmbusDevice) Unbind() error {
 	return unbindVmbusDeviceDriver(v.UUID, current)
 }
 
-func (v *VmbusDevice) CurrentDriver() (string, error) {
+func (v *vmbusDevice) CurrentDriver() (string, error) {
 	return GetCurrentVmbusDriver(v.UUID)
 }
 
-func (v *VmbusDevice) Probe() error {
+func (v *vmbusDevice) Probe() error {
 	return ErrNotProbe
 }
 
-func (v *VmbusDevice) ID() string {
+func (v *vmbusDevice) ID() string {
 	return v.UUID
 }
 
-func (v *VmbusDevice) String() string {
+func (v *vmbusDevice) String() string {
 	return vmbusDeviceStringer.With(v.UUID, v.Driver)
 }
 

--- a/devices/vmbus.go
+++ b/devices/vmbus.go
@@ -1,3 +1,8 @@
+// Copyright 2018 Intel Corporation.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package devices helps to query DPDK compatibles devices and to bind/unbind drivers
 package devices
 
 import (

--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -10,3 +10,4 @@ gtpu
 pingReplay
 timer
 netlink
+devbind

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -6,7 +6,7 @@ PATH_TO_MK = ../mk
 IMAGENAME = nff-go-examples
 EXECUTABLES = dump clonablePcapDumper kni copy errorHandling timer \
 			  createPacket sendFixedPktsNumber gtpu pingReplay \
-			  netlink gopacketParserExample
+			  netlink gopacketParserExample devbind
 SUBDIRS = nat tutorial antiddos demo fileReadWrite firewall forwarding
 
 .PHONY: dpi nffPktgen

--- a/examples/devbind.go
+++ b/examples/devbind.go
@@ -9,6 +9,7 @@ import (
 	"github.com/intel-go/nff-go/devices"
 )
 
+// Example that shows how to bind a driver to a NIC
 func main() {
 	nic := flag.String("nic", "enp0s9", "network interface to run DPDK")
 	bind := flag.String("bind", "igb_uio", "dpdk uio driver")
@@ -26,11 +27,11 @@ func main() {
 	defer func() {
 		flow.SystemStop()
 
-		// Bind to origin driver
+		// Re-Bind to original driver
 		device.Bind(driver)
 	}()
 
-	// Bind igb_uio driver
+	// Bind to new user specified driver
 	device.Bind(*bind)
 
 	config := &flow.Config{

--- a/examples/devbind.go
+++ b/examples/devbind.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"log"
+	"flag"
+
+	"github.com/intel-go/nff-go/flow"
+	"github.com/intel-go/nff-go/packet"
+	"github.com/intel-go/nff-go/devices"
+)
+
+func main() {
+	nic := flag.String("nic", "enp0s9", "network interface to run DPDK")
+	bind := flag.String("bind", "igb_uio", "dpdk uio driver")
+	flag.Parse()
+
+	device, err := devices.New(*nic)
+	flow.CheckFatal(err)
+
+	driver, err := device.CurrentDriver()
+	if err != nil {
+		log.Println("Failed to get CurrentDriver:", err)
+		return
+	}
+
+	defer func() {
+		flow.SystemStop()
+
+		// Bind to origin driver
+		device.Bind(driver)
+	}()
+
+	// Bind igb_uio driver
+	device.Bind(*bind)
+
+	config := &flow.Config{
+		HWTXChecksum: true,
+	}
+	flow.SystemInit(config)
+
+	var port uint16 = 0
+
+	mainFlow, err := flow.SetReceiver(port)
+	if err != nil {
+		log.Println("Failed to SetReceiver:", err)
+		return
+	}
+
+	err = flow.SetHandlerDrop(mainFlow, handler, nil)
+	if err != nil {
+		log.Println("Failed to SetHandlerDrop:", err)
+		return
+	}
+
+	err = flow.SetSender(mainFlow, port)
+	if err != nil {
+		log.Println("Failed to SetSender:", err)
+		return
+	}
+
+	err = flow.SystemStart()
+	if err != nil {
+		log.Println("Failed to SystemStart:", err)
+		return
+	}
+}
+
+func handler(*packet.Packet, flow.UserContext) bool {
+	return true
+}


### PR DESCRIPTION
examples: Binding a device by NIC

- adds new package `devices` to easily bind/unbind dpdk drivers to NICs - no PCI/VMBus IDs needed
- adds example code how to bind a dpdk driver (e.g. `igb_uio`) to a specified NIC (e.g. `eth1`)

Signed-off-by: Marcus Schiesser <marcus@glasnostic.com>