### PR TITLE
Fixed CI tests on ICMPv6 checksums

### DIFF
--- a/examples/nat/cksum.go
+++ b/examples/nat/cksum.go
@@ -64,7 +64,6 @@ func setIPv4ICMPChecksum(pkt *packet.Packet, calculateChecksum, hWTXChecksum boo
 			l3.HdrChecksum = packet.SwapBytesUint16(packet.CalculateIPv4Checksum(l3))
 		}
 		l4 := pkt.GetICMPNoCheck()
-		l4.Cksum = 0 // Need to zero l4.Cksum or otherwise it is included into calculation
 		l4.Cksum = packet.SwapBytesUint16(packet.CalculateIPv4ICMPChecksum(l3, l4,
 			unsafe.Pointer(uintptr(unsafe.Pointer(l4))+common.ICMPLen)))
 	}
@@ -111,7 +110,7 @@ func setIPv6ICMPChecksum(pkt *packet.Packet, calculateChecksum, hWTXChecksum boo
 		l3 := pkt.GetIPv6NoCheck()
 
 		l4 := pkt.GetICMPNoCheck()
-		l4.Cksum = 0 // Need to zero l4.Cksum or otherwise it is included into calculation
-		l4.Cksum = packet.SwapBytesUint16(packet.CalculateIPv6ICMPChecksum(l3, l4))
+		l4.Cksum = packet.SwapBytesUint16(packet.CalculateIPv6ICMPChecksum(l3, l4,
+			unsafe.Pointer(uintptr(unsafe.Pointer(l4))+common.ICMPLen)))
 	}
 }

--- a/examples/nffPktgen/generator/generator.go
+++ b/examples/nffPktgen/generator/generator.go
@@ -445,7 +445,7 @@ func generateICMPIP(pkt *packet.Packet, config *PacketConfig, rnd *rand.Rand) {
 		pktICMP.Cksum = packet.SwapBytesUint16(packet.CalculateIPv4ICMPChecksum(pktIP, pktICMP, pkt.Data))
 	} else if l3.Version == 6 {
 		pktIP := (*packet.IPv6Hdr)(pkt.L3)
-		pktICMP.Cksum = packet.SwapBytesUint16(packet.CalculateIPv6ICMPChecksum(pktIP, pktICMP))
+		pktICMP.Cksum = packet.SwapBytesUint16(packet.CalculateIPv6ICMPChecksum(pktIP, pktICMP, pkt.Data))
 	}
 }
 

--- a/packet/checksum_test.go
+++ b/packet/checksum_test.go
@@ -132,7 +132,6 @@ func TestCalculateIPv4ICMPChecksum(t *testing.T) {
 	pkt.GetIPv4().HdrChecksum = SwapBytesUint16(ipcksum)
 
 	want := wantIPv4ICMP
-	pkt.GetICMPNoCheck().Cksum = 0
 	got := CalculateIPv4ICMPChecksum(pkt.GetIPv4(), pkt.GetICMPForIPv4(), pkt.Data)
 
 	if got != want {
@@ -150,7 +149,7 @@ func TestCalculateIPv6ICMPChecksum(t *testing.T) {
 
 	want := wantIPv6ICMP
 	pkt.GetICMPNoCheck().Cksum = 0
-	got := CalculateIPv6ICMPChecksum(pkt.GetIPv6(), pkt.GetICMPNoCheck())
+	got := CalculateIPv6ICMPChecksum(pkt.GetIPv6(), pkt.GetICMPNoCheck(), pkt.Data)
 
 	if got != want {
 		t.Errorf("Incorrect result:\ngot: %x, \nwant: %x\n\n", got, want)

--- a/test/stability/testCksum/testCksum.go
+++ b/test/stability/testCksum/testCksum.go
@@ -588,7 +588,7 @@ func generateIPv6ICMP(emptyPacket *packet.Packet, rnd *rand.Rand) {
 	if !hwol {
 		pIPv6 := emptyPacket.GetIPv6()
 		pICMP := emptyPacket.GetICMPForIPv6()
-		pICMP.Cksum = packet.SwapBytesUint16(packet.CalculateIPv6ICMPChecksum(pIPv6, pICMP))
+		pICMP.Cksum = packet.SwapBytesUint16(packet.CalculateIPv6ICMPChecksum(pIPv6, pICMP, emptyPacket.Data))
 	}
 }
 

--- a/test/stability/testCksum/testCksumCommon/testCksumCommon.go
+++ b/test/stability/testCksum/testCksumCommon/testCksumCommon.go
@@ -96,9 +96,9 @@ func CheckPacketChecksums(p *packet.Packet) bool {
 			} else {
 				status = true
 			}
-		} else if pIPv6.Proto == common.ICMPNumber {
+		} else if pIPv6.Proto == common.ICMPv6Number {
 			pICMP := p.GetICMPForIPv6()
-			csum := packet.CalculateIPv6ICMPChecksum(pIPv6, pICMP)
+			csum := packet.CalculateIPv6ICMPChecksum(pIPv6, pICMP, p.Data)
 			if packet.SwapBytesUint16(pICMP.Cksum) != csum {
 				println("IPv6 ICMP checksum mismatch", packet.SwapBytesUint16(pICMP.Cksum), "should be", csum)
 			} else {
@@ -141,9 +141,9 @@ func CalculateChecksum(p *packet.Packet) {
 		} else if pIPv6.Proto == common.TCPNumber {
 			pTCP := p.GetTCPForIPv6()
 			pTCP.Cksum = packet.SwapBytesUint16(packet.CalculateIPv6TCPChecksum(pIPv6, pTCP, p.Data))
-		} else if pIPv6.Proto == common.ICMPNumber {
+		} else if pIPv6.Proto == common.ICMPv6Number {
 			pICMP := p.GetICMPForIPv6()
-			pICMP.Cksum = packet.SwapBytesUint16(packet.CalculateIPv6ICMPChecksum(pIPv6, pICMP))
+			pICMP.Cksum = packet.SwapBytesUint16(packet.CalculateIPv6ICMPChecksum(pIPv6, pICMP, p.Data))
 		} else {
 			println("Unknown IPv6 protocol number", pIPv6.Proto)
 			println("TEST FAILED")


### PR DESCRIPTION
Changed ICMPv6 checksum calculation to be consistent with other checksum
calculation functions. Now it is not necessary to zero out checksum
field in the header before calling checksum calculation.