### PR TITLE
Add GetPortByName and GetNameByPort

### DIFF
--- a/flow/flow.go
+++ b/flow/flow.go
@@ -974,6 +974,25 @@ func GetPortMACAddress(port uint16) [common.EtherAddrLen]uint8 {
 	return low.GetPortMACAddress(port)
 }
 
+// GetPortByName gets the port id from device name. The device name should be
+// specified as below:
+//
+// - PCIe address (Domain:Bus:Device.Function), for example- 0000:2:00.0
+// - SoC device name, for example- fsl-gmac0
+// - vdev dpdk name, for example- net_[pcap0|null0|tap0]
+func GetPortByName(name string) (uint16, error) {
+	return low.GetPortByName(name)
+}
+
+// GetNameByPort gets the device name from port id. The device name is specified as below:
+//
+// - PCIe address (Domain:Bus:Device.Function), for example- 0000:02:00.0
+// - SoC device name, for example- fsl-gmac0
+// - vdev dpdk name, for example- net_[pcap0|null0|tun0|tap0]
+func GetNameByPort(port uint16) (string, error) {
+	return low.GetNameByPort(port)
+}
+
 // SetIPForPort sets IP for specified port if it was created. Not thread safe.
 // Return error if requested port isn't exist or wasn't previously requested.
 func SetIPForPort(port uint16, ip uint32) error {


### PR DESCRIPTION
These are simple wrappers to `rte_eth_dev_get_port_by_name` and `rte_eth_dev_get_name_by_port` that I found useful. Not sure the best way to write tests for these funcs, so I figured I'd start this discussion to see if you even want to add these features.

I've found `GetPortByName` especially useful, because when a DPDK driver is bound, the easiest way to get a device's MAC address is to get its DPDK port by PCI address and then pass that to `low.GetPortMACAddress`.