### PR TITLE
Add new function SetSenderReceiverKNI

### DIFF
--- a/flow/scheduler.go
+++ b/flow/scheduler.go
@@ -101,6 +101,7 @@ const (
 	sendReceiveKNI // send to port, send to KNI, receive from KNI
 	generate
 	readWrite
+	comboKNI       // KNI send/receive will use core assigned to Linux KNI device
 )
 
 // Flow function representation
@@ -252,20 +253,26 @@ func (ff *flowFunction) startNewInstance(inIndex []int32, scheduler *scheduler) 
 
 func (ffi *instance) startNewClone(scheduler *scheduler, n int) (err error) {
 	ff := ffi.ff
-	core, index, err := scheduler.getCore()
-	if err != nil {
-		common.LogWarning(common.Debug, "Can't start new clone for", ff.name, "instance", n)
-		return err
+	var core int
+	var index int
+	if ff.fType != comboKNI {
+		core, index, err = scheduler.getCore()
+		if err != nil {
+			common.LogWarning(common.Debug, "Can't start new clone for", ff.name, "instance", n)
+			return err
+		}
+		common.LogDebug(common.Debug, "Start new clone for", ff.name, "instance", n, "at", core, "core")
+	} else {
+		common.LogDebug(common.Debug, "Start new clone for", ff.name, "instance", n, "at KNI Linux core")
 	}
-	common.LogDebug(common.Debug, "Start new clone for", ff.name, "instance", n, "at", core, "core")
 	ffi.clone = append(ffi.clone, &clonePair{index, [2]chan int{nil, nil}, process})
 	ffi.cloneNumber++
-	if ff.fType != receiveRSS && ff.fType != sendReceiveKNI {
+	if ff.fType != receiveRSS && ff.fType != sendReceiveKNI && ff.fType != comboKNI{
 		ffi.clone[ffi.cloneNumber-1].channel[0] = make(chan int)
 		ffi.clone[ffi.cloneNumber-1].channel[1] = make(chan int)
 	}
 	go func() {
-		if ff.fType != receiveRSS && ff.fType != sendReceiveKNI {
+		if ff.fType != receiveRSS && ff.fType != sendReceiveKNI && ff.fType != comboKNI {
 			if err := low.SetAffinity(core); err != nil {
 				common.LogFatal(common.Debug, "Failed to set affinity to", core, "core: ", err)
 			}
@@ -274,8 +281,10 @@ func (ffi *instance) startNewClone(scheduler *scheduler, n int) (err error) {
 			} else {
 				ff.uncloneFunction(ff.Parameters, ffi.inIndex, ffi.clone[ffi.cloneNumber-1].channel)
 			}
-		} else {
+		} else if ff.fType != comboKNI {
 			ff.cFunction(ff.Parameters, ffi.inIndex, &ffi.clone[ffi.cloneNumber-1].flag, core)
+		} else {
+			ff.cFunction(ff.Parameters, ffi.inIndex, &ffi.clone[ffi.cloneNumber-1].flag, 0)
 		}
 	}()
 	if ff.fType == segmentCopy || ff.fType == fastGenerate || ff.fType == generate {
@@ -297,7 +306,9 @@ func (ff *flowFunction) stopClone(ffi *instance, scheduler *scheduler) {
 			runtime.Gosched()
 		}
 	}
-	scheduler.setCoreByIndex(ffi.clone[ffi.cloneNumber-1].index)
+	if ffi.ff.fType != comboKNI {
+		scheduler.setCoreByIndex(ffi.clone[ffi.cloneNumber-1].index)
+	}
 	ffi.clone = ffi.clone[:len(ffi.clone)-1]
 	ffi.cloneNumber--
 	ffi.removed = true


### PR DESCRIPTION
SetSenderReceiverKNI combines send and receive KNI to one core.
With a parameter function can use core that is assigned for Linux KNI device.

Performance for 64 byte packets:
3 cores: 900MBits
2 cores:
without range: 700 MBits
with range: 1300 MBits
1 core: 2 MBits (however this is 44 MBits for 1400 byte packets)