### PR TITLE
Make receive cloning thread-safe

### DIFF
--- a/flow/scheduler.go
+++ b/flow/scheduler.go
@@ -745,13 +745,13 @@ func constructZeroIndex(old []int32) []int32 {
 }
 
 func constructDuplicatedIndex(old []int32, newIndex []int32) {
-	oldLen := old[0]/2 + old[0]%2
+	oldLen := old[0] / 2 + old[0]%2
 	newLen := old[0] / 2
+	old[0] = oldLen
 	for q := int32(0); q < newLen; q++ {
 		newIndex[q+1] = old[q+1+oldLen]
 	}
 	newIndex[0] = newLen
-	old[0] = oldLen
 }
 
 func constructNewIndex(inIndexNumber int32) []int32 {

--- a/low/low.go
+++ b/low/low.go
@@ -489,11 +489,12 @@ func (ring *Ring) GetRingCount() uint32 {
 }
 
 // ReceiveRSS - get packets from port and enqueue on a Ring.
-func ReceiveRSS(port uint16, inIndex []int32, OUT Rings, flag *int32, coreID int) {
+func ReceiveRSS(port uint16, inIndex []int32, OUT Rings, flag *int32, coreID int, race *int32) {
 	if C.rte_eth_dev_socket_id(C.uint16_t(port)) != C.int(C.rte_lcore_to_socket_id(C.uint(coreID))) {
 		common.LogWarning(common.Initialization, "Receive port", port, "is on remote NUMA node to polling thread - not optimal performance.")
 	}
-	C.receiveRSS(C.uint16_t(port), (*C.int32_t)(unsafe.Pointer(&(inIndex[0]))), C.extractDPDKRings((**C.struct_nff_go_ring)(unsafe.Pointer(&(OUT[0]))), C.int32_t(len(OUT))), (*C.int)(unsafe.Pointer(flag)), C.int(coreID))
+	C.receiveRSS(C.uint16_t(port), (*C.int32_t)(unsafe.Pointer(&(inIndex[0]))), C.extractDPDKRings((**C.struct_nff_go_ring)(unsafe.Pointer(&(OUT[0]))), C.int32_t(len(OUT))),
+		     (*C.int)(unsafe.Pointer(flag)), C.int(coreID), (*C.int)(unsafe.Pointer(race)))
 }
 
 func SrKNI(port uint16, flag *int32, coreID int, recv bool, OUT Rings, send bool, IN Rings) {


### PR DESCRIPTION
Remove behavior connected with parallel access to
one receive queue from multiple threads