### PR TITLE
Enabled Mellanox network drivers in DPDK for #467

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,9 @@ RUN apt-get -q update && apt-get -q -y install \
     hugepages  \
     libnuma-dev \
     libhyperscan-dev \
-    liblua5.3-dev
+    liblua5.3-dev \
+    libmnl-dev \
+    libibverbs-dev
 
 RUN cd /opt && curl -L -s https://dl.google.com/go/go1.11.4.linux-amd64.tar.gz | tar zx
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,10 @@ Requirements in the DPDK Getting Started Guide for
 Linux](http://dpdk.org/doc/guides/linux_gsg/sys_reqs.html) for more
 information.
 
+Since NFF-Go is build with Mellanox cards support out of the box you
+need to install additional dependencies required for MLX network
+drivers. On Ubuntu they are called `libmnl-dev` and `libibverbs-dev`.
+
 Additional dependencies are required for pktgen, especially if you are
 running RedHat or CentOS Linux distributions. See [this
 file](https://git.dpdk.org/apps/pktgen-dpdk/tree/INSTALL.md?h=pktgen-3.5.9&id=d469543f651506a8c9fb7c667a060950c5d92649)

--- a/dpdk/Makefile
+++ b/dpdk/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2017 Intel Corporation. 
+# Copyright 2017-2019 Intel Corporation.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
@@ -8,9 +8,7 @@ IMAGENAME = nff-go-pktgen
 # Pktgen variables
 NOCHECK_PKTGEN = yes
 
-# Main DPDK variables
-DPDK_INSTALL_DIR=$(RTE_TARGET)-install
-export WORKDIR=/workdir
+include $(PATH_TO_MK)/leaf.mk
 
 # Disable FSGSBASE and F16C to run in VMs and Docker containers.
 export EXTRA_CFLAGS = -mno-fsgsbase -mno-f16c
@@ -25,7 +23,9 @@ all: pktgen
 
 $(DPDK_DIR)/$(DPDK_INSTALL_DIR):
 	$(MAKE) -C $(DPDK_DIR) config T=$(RTE_TARGET)
-	$(MAKE) -C $(DPDK_DIR) install T=$(RTE_TARGET) DESTDIR=$(DPDK_INSTALL_DIR)
+	sed -ri 's,(MLX._PMD=)n,\1y,' $(DPDK_DIR)/build/.config
+	$(MAKE) -C $(DPDK_DIR)
+	$(MAKE) -C $(DPDK_DIR) install DESTDIR=$(DPDK_INSTALL_DIR)
 
 $(PKTGEN_DIR)/app/$(RTE_TARGET)/pktgen: $(DPDK_DIR)/$(DPDK_INSTALL_DIR)
 	$(MAKE) -C $(PKTGEN_DIR)
@@ -34,8 +34,7 @@ pktgen: $(PKTGEN_DIR)/app/$(RTE_TARGET)/pktgen
 	cp $(PKTGEN_DIR)/app/$(RTE_TARGET)/pktgen .
 
 clean:
-	-$(MAKE) -C $(DPDK_DIR) clean
-	-rm -rf $(DPDK_DIR)/$(DPDK_INSTALL_DIR) $(DPDK_DIR)/build $(DPDK_DIR)/$(RTE_TARGET)
 	-$(MAKE) -C $(PKTGEN_DIR) realclean
-
-include $(PATH_TO_MK)/leaf.mk
+	-rm pktgen
+	-$(MAKE) -C $(DPDK_DIR) clean
+	-rm -rf $(DPDK_DIR)/$(DPDK_INSTALL_DIR) $(DPDK_DIR)/build

--- a/low/low.go
+++ b/low/low.go
@@ -13,7 +13,7 @@ package low
 // it increases executable size and build time.
 
 /*
-#cgo LDFLAGS: -lrte_distributor -lrte_reorder -lrte_kni -lrte_pipeline -lrte_table -lrte_port -lrte_timer -lrte_jobstats -lrte_lpm -lrte_power -lrte_acl -lrte_meter -lrte_sched -lrte_vhost -lrte_ip_frag -lrte_cfgfile -Wl,--whole-archive -Wl,--start-group -lrte_kvargs -lrte_mbuf -lrte_hash -lrte_ethdev -lrte_mempool -lrte_ring -lrte_mempool_ring -lrte_eal -lrte_cmdline -lrte_net -lrte_bus_pci -lrte_pci -lrte_bus_vdev -lrte_timer -lrte_pmd_bond -lrte_pmd_vmxnet3_uio -lrte_pmd_virtio -lrte_pmd_cxgbe -lrte_pmd_enic -lrte_pmd_i40e -lrte_pmd_fm10k -lrte_pmd_ixgbe -lrte_pmd_e1000 -lrte_pmd_ena -lrte_pmd_ring -lrte_pmd_af_packet -lrte_pmd_null -Wl,--end-group -Wl,--no-whole-archive -lrt -lm -ldl -lnuma
+#cgo LDFLAGS: -lrte_distributor -lrte_reorder -lrte_kni -lrte_pipeline -lrte_table -lrte_port -lrte_timer -lrte_jobstats -lrte_lpm -lrte_power -lrte_acl -lrte_meter -lrte_sched -lrte_vhost -lrte_ip_frag -lrte_cfgfile -Wl,--whole-archive -Wl,--start-group -lrte_kvargs -lrte_mbuf -lrte_hash -lrte_ethdev -lrte_mempool -lrte_ring -lrte_mempool_ring -lrte_eal -lrte_cmdline -lrte_net -lrte_bus_pci -lrte_pci -lrte_bus_vdev -lrte_timer -lrte_pmd_bond -lrte_pmd_vmxnet3_uio -lrte_pmd_virtio -lrte_pmd_cxgbe -lrte_pmd_enic -lrte_pmd_i40e -lrte_pmd_fm10k -lrte_pmd_ixgbe -lrte_pmd_e1000 -lrte_pmd_ena -lrte_pmd_ring -lrte_pmd_af_packet -lrte_pmd_null -libverbs -lmnl -lmlx4 -lmlx5 -lrte_pmd_mlx4 -lrte_pmd_mlx5 -Wl,--end-group -Wl,--no-whole-archive -lrt -lm -ldl -lnuma
 #include "low.h"
 */
 import "C"

--- a/mk/include.mk
+++ b/mk/include.mk
@@ -6,11 +6,13 @@
 
 PROJECT_ROOT := $(abspath $(dir $(abspath $(lastword $(MAKEFILE_LIST))))/..)
 
+# Main DPDK variables
 DPDK_VERSION=18.11
 DPDK_DIR=dpdk
 PKTGEN_VERSION=3.5.8
 PKTGEN_DIR=pktgen-dpdk
-export RTE_SDK=$(PROJECT_ROOT)/dpdk/$(DPDK_DIR)
+DPDK_INSTALL_DIR=$(RTE_TARGET)-install
+export RTE_SDK=$(PROJECT_ROOT)/dpdk/$(DPDK_DIR)/$(DPDK_INSTALL_DIR)/usr/local/share/dpdk
 export RTE_TARGET=x86_64-native-linuxapp-gcc
 
 # Configure flags for native code. Disable FSGSBASE and F16C to run in

--- a/nff-go-base/Makefile
+++ b/nff-go-base/Makefile
@@ -17,7 +17,7 @@ Fedora: Makefile
 		echo 'ENV https_proxy ${https_proxy}' >> Dockerfile;	\
 		echo 'RUN echo proxy=${http_proxy} >> /etc/dnf/dnf.conf' >> Dockerfile;	\
 	fi
-	echo 'RUN dnf -y install numactl-libs.x86_64; dnf clean all' >> Dockerfile
+	echo 'RUN dnf -y install numactl-libs.x86_64 lua-devel libmnl-devel rdma-core-devel libibverbs; dnf clean all' >> Dockerfile
 	echo 'CMD ["/bin/bash"]' >> Dockerfile
 
 Dockerfile: Makefile
@@ -29,7 +29,7 @@ Dockerfile: Makefile
 		echo 'RUN echo Acquire::http::Proxy \"${http_proxy}\"\; >> /etc/apt/apt.conf' >> Dockerfile;    \
 		echo 'RUN echo Acquire::https::Proxy \"${https_proxy}\"\; >> /etc/apt/apt.conf' >> Dockerfile;    \
 	fi
-	echo 'RUN apt-get update; apt-get install -y pciutils; apt-get install -y libnuma-dev; apt-get install -y libpcap0.8-dev; apt-get install -y liblua5.3-dev; apt-get clean all' >> Dockerfile
+	echo 'RUN apt-get update; apt-get install -y pciutils libnuma-dev libpcap0.8-dev liblua5.3-dev libibverbs-dev libmnl-dev; apt-get clean all' >> Dockerfile
 	echo 'CMD ["/bin/bash"]' >> Dockerfile
 
 .PHONY: dpdk

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -103,7 +103,8 @@ SHELL
 $provision_fedora = <<SHELL
 echo Installing system packages
 sudo dnf update -y
-sudo dnf install -y python make gcc git numactl-devel libpcap-devel elfutils-libelf-devel lua-devel NetworkManager net-tools redhat-lsb-core pciutils kernel-modules kernel-devel wget vim protobuf-compiler
+sudo dnf install -y python make gcc git numactl-devel libpcap-devel elfutils-libelf-devel lua-devel NetworkManager net-tools redhat-lsb-core pciutils kernel-modules kernel-devel wget vim protobuf-compiler libibverbs-utils rdma-core-devel librdmacm-utils libmnl-devel
+sudo ln -s lua.pc /usr/lib64/pkgconfig/lua5.3.pc
 sudo systemctl enable NetworkManager
 sudo systemctl start NetworkManager
 SHELL
@@ -111,7 +112,7 @@ SHELL
 $provision_ubuntu = <<SHELL
 echo Installing system packages
 sudo apt-get update
-sudo apt-get install -y python make gcc git libnuma-dev libpcap0.8-dev libelf-dev liblua5.3-dev network-manager protobuf-compiler
+sudo apt-get install -y python make gcc git libnuma-dev libpcap0.8-dev libelf-dev liblua5.3-dev network-manager protobuf-compiler libibverbs-dev ibverbs-utils rdma-core rdmacm-utils librdmacm-dev libmnl-dev
 sudo systemctl enable network-manager
 sudo systemctl start network-manager
 


### PR DESCRIPTION
Added libmnl-dev and libibverbs-dev dependencies in docker images
Fixed DPDK build to reqire generated config file instead of stock