### PR TITLE
nffpktgen improvements

### DIFF
--- a/examples/nffPktgen/generator/parseConfig.go
+++ b/examples/nffPktgen/generator/parseConfig.go
@@ -585,12 +585,17 @@ func parseRandBytes(in map[string]interface{}) (RandBytes, error) {
 
 func parsePdist(in []interface{}) ([]PDistEntry, error) {
 	pdist := []PDistEntry{}
+	var totalProb float64
 	for _, v := range in {
 		pdistElem, err := parsePdistEntry(v.(map[string]interface{}))
 		if err != nil {
 			return []PDistEntry{}, fmt.Errorf("parsing pdistentry returned: %v", err)
 		}
+		totalProb += pdistElem.Probability
 		pdist = append(pdist, pdistElem)
+	}
+	if totalProb != 1 {
+		return []PDistEntry{{}}, fmt.Errorf("Sum of probabilities of pdist elements is not equal to 1")
 	}
 	return pdist, nil
 }

--- a/examples/nffPktgen/testing/ip4icmp.json
+++ b/examples/nffPktgen/testing/ip4icmp.json
@@ -18,20 +18,20 @@
                        "seq": "increasing",
                         "pdist": [
                             {
-                                "probability": 0.3,
+                                "probability": 0.33,
                                 "randbytes":    {
                                     "size": 50,
                                     "deviation": 10
                                 }
                             },
                             {
-                                "probability": 0.3,
+                                "probability": 0.33,
                                 "raw": {
                                     "data": "sfsfsfs"
                                 }
                             },
                             {
-                                "probability": 0.3,
+                                "probability": 0.34,
                                 "raw": {
                                     "data": "0000000000000000000000000000000000"
                                 }

--- a/examples/nffPktgen/testing/ip6icmp.json
+++ b/examples/nffPktgen/testing/ip6icmp.json
@@ -16,14 +16,14 @@
                        "seq": "increasing",
                         "pdist": [
                             {
-                                "probability": 0.3,
+                                "probability": 0.5,
                                 "randbytes":    {
                                     "size": 50,
                                     "deviation": 10
                                 }
                             },
                             {
-                                "probability": 0.3,
+                                "probability": 0.5,
                                 "raw": {
                                     "data": "0000000000000000000000000000000000"
                                 }

--- a/examples/nffPktgen/testing/ip6tcp.json
+++ b/examples/nffPktgen/testing/ip6tcp.json
@@ -32,7 +32,7 @@
                                 }
                             },
                             {
-                                "probability": 0.2,
+                                "probability": 0.3,
                                 "raw": {
                                     "data": "sfsfsfs"
                                 }


### PR DESCRIPTION
1) Remove unnecessary checks from pdist
2) Replace 1 byte rand to 8 byte rand (should be vector rand in the future)

  | old (1 core) | new (1 core) |  
-- | -- | -- | --
arp.json | 5701 | 5776 | 1%
arpVlan.json | 5071 | 5043 | -1%
ip4icmp.json | 1855 | 2980 | 61%
ip4.json | 4973 | 4994 | 0%
ip4tcp.json | 1799 | 3092 | 72%
ip4tcpVlan.json | 1837 | 3043 | 66%
ip4udp.json | 1743 | 3020 | 73%
ip4udpVlan.json | 1732 | 2952 | 70%
mix.json | 904 | 6193 | 585%
vlanTag.json | 1375 | 3673 | 167%

