### PR TITLE
For instructions like lpm.Lookup(DstAddr, &DstAddr)

### DIFF
--- a/packet/packet.go
+++ b/packet/packet.go
@@ -887,8 +887,8 @@ func (lpm *LPM) Lookup(ip types.IPv4Address, nextHop *types.IPv4Address) bool {
 		tbl_entry = (*lpm.tbl8)[tbl8_index]
 	}
 
-	*nextHop = tbl_entry & 0x00FFFFFF
 	if tbl_entry&low.RteLpmLookupSuccess != 0 {
+		*nextHop = tbl_entry & 0x00FFFFFF
 		return true
 	}
 	return false


### PR DESCRIPTION
We need not to spoil next_hop if address is not in lookup table