### PR TITLE
refactor: fix code and comments typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Go Report Card](https://goreportcard.com/badge/github.com/intel-go/yanff)](https://goreportcard.com/report/github.com/intel-go/yanff) 
+[![Go Report Card](https://goreportcard.com/badge/github.com/intel-go/nff-go)](https://goreportcard.com/report/github.com/intel-go/nff-go) 
 [![GoDoc](https://godoc.org/github.com/intel-go/nff-go?status.svg)](https://godoc.org/github.com/intel-go/nff-go)
 [![Dev chat at https://gitter.im/intel-yanff/Lobby](https://img.shields.io/badge/gitter-developer_chat-46bc99.svg)](https://gitter.im/intel-yanff/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Build Status](https://travis-ci.org/intel-go/nff-go.svg?branch=develop)](https://travis-ci.org/intel-go/nff-go)

--- a/packet/gtp.go
+++ b/packet/gtp.go
@@ -36,7 +36,7 @@ const (
 )
 
 type UDPPort struct {
-	Lenght              uint8 // in 4 octets, here always 0x01
+	Length              uint8 // in 4 octets, here always 0x01
 	UDPPortNumber       uint16
 	NextExtensionHeader uint8
 }

--- a/packet/packet.go
+++ b/packet/packet.go
@@ -838,7 +838,7 @@ func NewPacket() (*Packet, error) {
 	return pkt, nil
 }
 
-// SendPacket immidiately sends packet to specified port via calling C function.
+// SendPacket immediately sends packet to specified port via calling C function.
 // Packet is freed. Function return true if packet was actually sent.
 // Port should be initialized. Packet is sent to zero queue (is always present).
 // Sending simultaneously to one port is permitted in DPDK.

--- a/test/stability/stabilityCommon/common.go
+++ b/test/stability/stabilityCommon/common.go
@@ -129,7 +129,7 @@ func InitCommonState(configFile, target string) {
 		return
 	}
 
-	// Get destination MAC addressess for port 0 and 1 from config file
+	// Get destination MAC addresses for port 0 and 1 from config file
 	if hw, err := net.ParseMAC(config[target][0]); err == nil {
 		copy(dstMac0[:], hw)
 	} else {


### PR DESCRIPTION
Fixes code misspelling from https://goreportcard.com/report/github.com/intel-go/nff-go#misspell
and Readme gotreportcard link.