### PR TITLE
fix device/binder can't handle correctly with network interface with `virtio-pci` driver on KVM

### DIFF
--- a/devices/consts.go
+++ b/devices/consts.go
@@ -75,7 +75,7 @@ var (
 
 var (
 	pathSysClassNetDeviceDriver stringBuilder = PathSysClassNet + "/%s/device/driver"
-	pathSysClassNetDevice       stringBuilder = PathSysClassNet + "/%s/device"
+	pathSysClassNetDevice       stringBuilder = PathSysClassNet + "/%s"
 )
 
 var (


### PR DESCRIPTION
virtio-pci device have a different deviice reference
e.g:

	device -> ../../../virtio1

was expected as:

	device -> ../../../0000:00:03.0

Change to read the link from device name folder 
and parse device ID from the path

	$ readlink /sys/class/net/ens6
	/sys/devices/pci0000:00/0000:00:06.0/virtio1/net/ens6

Signed-off-by: Yu-Han Lin guesslin@glasnostic.com