### PR TITLE
fix get PCI device ID

### DIFF
--- a/devices/misc.go
+++ b/devices/misc.go
@@ -42,20 +42,16 @@ func GetDeviceID(nicName string) (string, error) {
 	// raw should be like /sys/devices/pci0002:00/0000:00:08.0/virtio2/net/ens8
 	// or /sys/devices/pci0000:00/0000:00:01.0/0000:03:00.2/net/ens4f2
 	raws := strings.Split(raw, "/")
-	if len(raws) < 5 {
+	if len(raws) < 6 {
 		return "", fmt.Errorf("path not correct")
 	}
-
-	// search and validate deviceID
-	for idx := len(raws) - 1; idx >= 0; idx-- {
-		v := strings.Split(raws[idx], ":")
-		if len(v) == 3 {
-			if len(v[0]) == 4 && len(v[1]) == 2 && len(v[2]) == 4 {
-				return raws[idx], nil
-			}
-		}
+	if IsPciID.Match([]byte(raws[5])) {
+		return raws[5], nil
+	} else if IsPciID.Match([]byte(raws[4])) {
+		return raws[4], nil
+	} else {
+		return "", fmt.Errorf("can't get device ID from path: %s", raw)
 	}
-	return "", fmt.Errorf("path not correct")
 }
 
 // IsModuleLoaded checks if the kernel has already loaded the driver or not.


### PR DESCRIPTION
For some NIC the readlink `/sys/class/net/<nic_name>` would get several
PCI address and the correct one would be the second one, e.g.

    $ readlink -f /sys/class/net/ens224
    /sys/devices/pci0000:00/0000:00:17.0/0000:13:00.0/net/ens224

To get the correct device ID, we have to check if the second one
`0000:13:00.0` is a PCI address, return the second one, else return the
first one `0000:00:17.0`

Signed-off-by: Yu-Han Lin guesslin@glasnostic.com