### PR TITLE
Release 0.9.1

### DIFF
--- a/test/stability/testCksum/Makefile
+++ b/test/stability/testCksum/Makefile
@@ -6,7 +6,8 @@ PATH_TO_MK = ../../../mk
 IMAGENAME = nff-go-test-cksum
 EXECUTABLES = testCksum
 
+.PHONY: testing
 testing: check-pktgen
-	go test -v -test.timeout 15m
+	go test -v -tags "${GO_BUILD_TAGS}" -test.timeout 15m
 
 include $(PATH_TO_MK)/leaf.mk

--- a/test/stability/testMerge/Makefile
+++ b/test/stability/testMerge/Makefile
@@ -9,7 +9,8 @@ EXECUTABLES = testMerge
 all:
 	cp ../../framework/main/config.json .
 
+.PHONY: testing
 testing: check-pktgen
-	go test -v -test.timeout 20m
+	go test -v -tags "${GO_BUILD_TAGS}" -test.timeout 20m
 
 include $(PATH_TO_MK)/leaf.mk

--- a/test/stability/testSingleWorkingFF/Makefile
+++ b/test/stability/testSingleWorkingFF/Makefile
@@ -9,7 +9,8 @@ EXECUTABLES = testSingleWorkingFF
 all:
 	cp ../../framework/main/config.json .
 
+.PHONY: testing
 testing: check-pktgen
-	go test
+	go test -v -tags "${GO_BUILD_TAGS}"
 
 include $(PATH_TO_MK)/leaf.mk


### PR DESCRIPTION
Fixed tests to build correctly with BPF enabled.