### PR TITLE
Adjust PciID Detection for Azure VMs

### DIFF
--- a/devices/misc.go
+++ b/devices/misc.go
@@ -49,6 +49,8 @@ func GetDeviceID(nicName string) (string, error) {
 		return raws[5], nil
 	} else if IsPciID.Match([]byte(raws[4])) {
 		return raws[4], nil
+	} else if len(raws) >= 10 && IsPciID.Match([]byte(raws[10])) {
+		return raws[10], nil
 	} else {
 		return "", fmt.Errorf("can't get device ID from path: %s", raw)
 	}


### PR DESCRIPTION
On Azure the Device Path looks like this:
```
/sys/devices/LNXSYSTM:00/LNXSYBUS:00/PNP0A03:00/device:07/VMBUS:01/a8d9c125-e470-4364-a0b0-a2dd18ed6883/pci0002:00/0002:00:02.0/net/enP2s2
```

