### PR TITLE
flow/predefined: fix handleARPICMPRequests

### DIFF
--- a/flow/predefined.go
+++ b/flow/predefined.go
@@ -69,7 +69,11 @@ func handleARPICMPRequests(current *packet.Packet, context UserContext) bool {
 			(answerPacket.GetICMPNoCheck()).Type = types.ICMPTypeEchoResponse
 			ipv4.HdrChecksum = packet.SwapBytesUint16(packet.CalculateIPv4Checksum(ipv4))
 			answerPacket.ParseL7(types.ICMPNumber)
-			icmp.Cksum = packet.SwapBytesUint16(packet.CalculateIPv4ICMPChecksum(ipv4, icmp, answerPacket.Data))
+			(answerPacket.GetICMPNoCheck()).Cksum = packet.SwapBytesUint16(
+				packet.CalculateIPv4ICMPChecksum(
+					answerPacket.GetIPv4NoCheck(),
+					answerPacket.GetICMPNoCheck(),
+					answerPacket.Data))
 
 			answerPacket.SendPacket(port.port)
 


### PR DESCRIPTION
The checksum must be calculated on the echo response.

Currently it gets calculated on the received echo request,
so the response gets sent with a wrong checksum.

More strict OS, like OpenBSD, drop ICMP Packets with
a wrong checksum.