### PR TITLE
flow/predefined: allow further processing

### DIFF
--- a/flow/predefined.go
+++ b/flow/predefined.go
@@ -19,12 +19,12 @@ func handleARPICMPRequests(current *packet.Packet, context UserContext) bool {
 	if arp != nil {
 		if packet.SwapBytesUint16(arp.Operation) != packet.ARPRequest ||
 			arp.THA != [types.EtherAddrLen]byte{} {
-			return false
+			return true
 		}
 
 		port := portPair[types.ArrayToIPv4(arp.TPA)]
 		if port == nil {
-			return false
+			return true
 		}
 
 		// Prepare an answer to this request


### PR DESCRIPTION
ARP Replies would be dropped if you use this predefined method.
So just let it drop the packet if the method actually handled it.

ICMP was already handled correctly.

Signed-off-by: Stefan Rinkes <stefan.rinkes@gmail.com>