### PR TITLE
internal/low: add LookupRing API

### DIFF
--- a/internal/low/low.go
+++ b/internal/low/low.go
@@ -274,6 +274,11 @@ const (
 	RteLpmLookupSuccess        = C.RTE_LPM_LOOKUP_SUCCESS
 )
 
+// Lookup ring with given name.
+func LookupRing(name string) *Ring {
+	return (*Ring)(unsafe.Pointer(C.nff_go_ring_lookup(C.CString(name))))
+}
+
 // CreateRing creates ring with given name and count.
 func CreateRing(count uint) *Ring {
 	name := strconv.Itoa(ringName)
@@ -615,7 +620,7 @@ func CreatePort(port uint16, willReceive bool, promiscuous bool, hwtxchecksum,
 		mempools = nil
 	}
 	if C.port_init(C.uint16_t(port), C.bool(willReceive), mempools,
-		C._Bool(promiscuous), C._Bool(hwtxchecksum), C._Bool(hwrxpacketstimestamp), C.int32_t(inIndex), C.int32_t (tXQueuesNumberPerPort)) != 0 {
+		C._Bool(promiscuous), C._Bool(hwtxchecksum), C._Bool(hwrxpacketstimestamp), C.int32_t(inIndex), C.int32_t(tXQueuesNumberPerPort)) != 0 {
 		msg := common.LogError(common.Initialization, "Cannot init port ", port, "!")
 		return common.WrapWithNFError(nil, msg, common.FailToInitPort)
 	}

--- a/internal/low/low.h
+++ b/internal/low/low.h
@@ -1,4 +1,4 @@
-// Copyright 2017 Intel Corporation. 
+// Copyright 2017 Intel Corporation.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
@@ -857,6 +857,18 @@ struct rte_ring** extractDPDKRings(struct nff_go_ring** r, int32_t inIndexNumber
 		output[i] = r[i]->DPDK_ring;
 	}
 	return output;
+}
+
+struct nff_go_ring *
+nff_go_ring_lookup(const char *name) {
+	struct nff_go_ring* r = malloc(sizeof(struct nff_go_ring));
+
+	r->DPDK_ring = rte_ring_lookup(name);
+	// Ring elements are located immidiately behind rte_ring structure
+	// So ring[1] is pointed to the beginning of this data
+	r->internal_DPDK_ring = &(r->DPDK_ring)[1];
+	r->offset = sizeof(void*);
+	return r;
 }
 
 struct nff_go_ring *


### PR DESCRIPTION
If the dpdk run with secondary mode, LookupRing will be useful.

Signed-off-by: ChenYahui2019 <goodluckwillcomesoon@gmail.com>