### PR TITLE
Export GetPortsNumber in flow package

### DIFF
--- a/flow/flow.go
+++ b/flow/flow.go
@@ -1288,6 +1288,11 @@ func GetPortMACAddress(port uint16) [types.EtherAddrLen]uint8 {
 	return low.GetPortMACAddress(port)
 }
 
+// GetPortsNumber gets total number of available Ethernet devices.
+func GetPortsNumber() int {
+	return low.GetPortsNumber()
+}
+
 // GetPortByName gets the port id from device name. The device name should be
 // specified as below:
 //


### PR DESCRIPTION
	For user who want to get the number of device ports on system,
	better to get it from rte_eth_dev_count function in rte_ethdev.h
	But while a Go application include this rte_ethdev.h header and
	nff-go library will cause a RTR_HASH error.
	See https://github.com/intel-go/nff-go/issues/649 for detail
	information about the error message.

Signed-off-by: Yu-Han Lin guesslin@glasnostic.com