### PR TITLE
fix read pcap indefinitely

### DIFF
--- a/flow/flow.go
+++ b/flow/flow.go
@@ -1926,7 +1926,7 @@ func read(parameters interface{}, inIndex []int32, stopper [2]chan int) {
 			stopper[1] <- 1
 			return
 		default:
-			if count >= repcount {
+			if count >= repcount && repcount >= 0 {
 				break
 			}
 			tempPacket, err := packet.NewPacket()


### PR DESCRIPTION
The description of the SetReceiverFile function indicates that to read a pcap indefinitely, set repcount=-1. See [here](https://github.com/intel-go/nff-go/blob/master/flow/flow.go#L878)
But the read function stops when comparing the current count to repcount.
This PR handles the case where repcount = -1.